### PR TITLE
Fix installation command for all skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every skill is self-contained. No skill depends on another. Install only what yo
 Install all skills:
 
 ```
-npx skills add dpearson2699/swift-ios-skills --all
+npx skills add dpearson2699/swift-ios-skills
 ```
 
 Install specific skills:


### PR DESCRIPTION
I removed the --all because this is VERY annoying that it installs like 30-40 different folders for each AI coding platform in existence. I don't think many people are wanting to do this in any case.