### PR TITLE
Improve Tessl quality across skill catalog

### DIFF
--- a/evals/audioaccessorykit-stale-api-review/criteria.json
+++ b/evals/audioaccessorykit-stale-api-review/criteria.json
@@ -48,8 +48,8 @@
       "max_score": 5
     },
     {
-      "name": "No unrelated rewrite",
-      "description": "Does not turn the review into broad BLE discovery, UI, or unrelated audio session guidance.",
+      "name": "Capability accuracy",
+      "description": "Declares only capabilities the hardware can actually support and treats placement as requiring ongoing placement updates.",
       "max_score": 5
     }
   ]

--- a/evals/gamekit-identity-saved-games/criteria.json
+++ b/evals/gamekit-identity-saved-games/criteria.json
@@ -33,8 +33,8 @@
       "max_score": 15
     },
     {
-      "name": "No unrelated overreach",
-      "description": "Keeps the output to GameKit client/server guidance and does not create an app project, backend service, or unrelated storage architecture.",
+      "name": "Public key verification",
+      "description": "Has the server fetch the Apple-provided public key and verify the signature over the covered fields instead of trusting client-supplied identity data directly.",
       "max_score": 10
     }
   ]

--- a/evals/photokit-camera-lifecycle-review/capability.txt
+++ b/evals/photokit-camera-lifecycle-review/capability.txt
@@ -1,0 +1,1 @@
+Serialized camera lifecycle

--- a/evals/photokit-camera-lifecycle-review/criteria.json
+++ b/evals/photokit-camera-lifecycle-review/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Tests whether camera configuration and session state changes are serialized with balanced transactions and correct UI boundaries.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Single owner",
+      "description": "Assigns AVCaptureSession configuration, startRunning, and stopRunning to one dedicated non-main serial executor or queue.",
+      "max_score": 25
+    },
+    {
+      "name": "No detached race",
+      "description": "Does not mix main-actor configuration with detached or unrelated-queue start and stop operations.",
+      "max_score": 15
+    },
+    {
+      "name": "Balanced transaction",
+      "description": "Guarantees every beginConfiguration call reaches commitConfiguration, including early error paths.",
+      "max_score": 20
+    },
+    {
+      "name": "Graph checks",
+      "description": "Checks canAddInput and canAddOutput before changing the capture graph.",
+      "max_score": 15
+    },
+    {
+      "name": "Permission ordering",
+      "description": "Resolves camera authorization before entering the session configuration transaction.",
+      "max_score": 10
+    },
+    {
+      "name": "Preview boundary",
+      "description": "Keeps session ownership in a controller and limits UIViewRepresentable to displaying the AVCaptureVideoPreviewLayer.",
+      "max_score": 15
+    }
+  ]
+}

--- a/evals/photokit-camera-lifecycle-review/task.md
+++ b/evals/photokit-camera-lifecycle-review/task.md
@@ -1,0 +1,21 @@
+# Camera Session Concurrency Review
+
+## Problem/Feature Description
+
+A SwiftUI camera screen intermittently freezes during launch and sometimes
+reports that its capture session is in an invalid configuration state. The
+controller configures the session from UI-isolated code, starts it from an
+unstructured background task, and stops it from a separate callback queue. One
+configuration guard can also exit before the transaction is closed.
+
+Review the lifecycle and propose a small controller design that removes the
+races while keeping the preview responsive.
+
+## Output Specification
+
+Create `camera-lifecycle-review.md` containing:
+
+- the corrected ownership and serialization model;
+- pseudocode or Swift for configuration, start, and stop;
+- the permission ordering and configuration failure path; and
+- the responsibility of the SwiftUI preview wrapper.

--- a/evals/photokit-framework-boundary/capability.txt
+++ b/evals/photokit-framework-boundary/capability.txt
@@ -1,0 +1,1 @@
+Media framework boundaries

--- a/evals/photokit-framework-boundary/criteria.json
+++ b/evals/photokit-framework-boundary/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Tests whether PhotoKit guidance owns selection, explicit library access, camera capture, and image handling without absorbing playback or cache architecture.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Picker ownership",
+      "description": "Keeps PhotosPicker or PHPickerViewController selection and PhotosPickerItem loading in PhotoKit scope.",
+      "max_score": 20
+    },
+    {
+      "name": "Library ownership",
+      "description": "Keeps PHPhotoLibrary authorization, limited access, and custom asset browsing in PhotoKit scope.",
+      "max_score": 20
+    },
+    {
+      "name": "Camera ownership",
+      "description": "Keeps AVCaptureSession camera configuration and capture lifecycle in the camera-capture portion of the skill.",
+      "max_score": 20
+    },
+    {
+      "name": "Playback handoff",
+      "description": "Routes detailed AVPlayer and playback-session behavior to AVKit or dedicated AVFoundation playback guidance.",
+      "max_score": 15
+    },
+    {
+      "name": "Caching handoff",
+      "description": "Routes production remote-image cache architecture to dedicated image-loading or networking guidance while retaining display downsampling advice.",
+      "max_score": 15
+    },
+    {
+      "name": "Permission boundary",
+      "description": "Does not require full photo-library access for the picker-only path and requests explicit access only for full-library operations.",
+      "max_score": 10
+    }
+  ]
+}

--- a/evals/photokit-framework-boundary/task.md
+++ b/evals/photokit-framework-boundary/task.md
@@ -1,0 +1,17 @@
+# Media Feature Ownership Plan
+
+## Problem/Feature Description
+
+A team is planning one media feature that lets users choose a few photos,
+browse their entire library in a custom screen, capture a new photo, show remote
+thumbnails, and play recorded video. They want one concise ownership note so the
+implementation does not turn a single skill into a catch-all media guide.
+
+Describe which parts belong together and where the plan should hand off to
+adjacent framework guidance.
+
+## Output Specification
+
+Create `media-feature-boundaries.md` with a responsibility table and a short
+implementation sequence. Include the permission boundary between picker-only
+selection and full-library browsing.

--- a/evals/photokit-picker-memory-privacy/capability.txt
+++ b/evals/photokit-picker-memory-privacy/capability.txt
@@ -1,0 +1,1 @@
+Privacy-preserving photo import

--- a/evals/photokit-picker-memory-privacy/criteria.json
+++ b/evals/photokit-picker-memory-privacy/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Tests privacy-preserving photo selection, asynchronous media loading, permission scope, and display-sized decoding.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Modern picker",
+      "description": "Uses PhotosPicker or PHPickerViewController rather than UIImagePickerController for user-selected library media.",
+      "max_score": 15
+    },
+    {
+      "name": "Picker privacy",
+      "description": "States that browsing and selecting through the system picker does not require broad photo-library permission.",
+      "max_score": 20
+    },
+    {
+      "name": "Async loading",
+      "description": "Loads PhotosPickerItem content asynchronously with loadTransferable and handles nil or thrown decode failures.",
+      "max_score": 15
+    },
+    {
+      "name": "Display downsampling",
+      "description": "Downsamples original image data with CGImageSource to the target display size before creating grid images.",
+      "max_score": 25
+    },
+    {
+      "name": "Explicit access scope",
+      "description": "Requests read-write photo-library access only for full-library operations such as a custom asset browser and accounts for limited access.",
+      "max_score": 15
+    },
+    {
+      "name": "Usage descriptions",
+      "description": "Associates NSPhotoLibraryUsageDescription or NSPhotoLibraryAddUsageDescription with the explicit read or write operations that require them.",
+      "max_score": 10
+    }
+  ]
+}

--- a/evals/photokit-picker-memory-privacy/task.md
+++ b/evals/photokit-picker-memory-privacy/task.md
@@ -1,0 +1,21 @@
+# Photo Import Grid Review
+
+## Problem/Feature Description
+
+A travel-journal app imports several user-selected photos into a SwiftUI grid.
+The current implementation asks for broad library access before opening the
+picker, converts every selected original directly into a `UIImage`, and updates
+the grid as each conversion finishes. Recent devices can supply very large
+images, and the feature now shows memory spikes and confusing permission UI.
+
+Review the design and provide a corrected implementation outline that preserves
+user privacy and keeps thumbnail memory predictable.
+
+## Output Specification
+
+Create `photo-import-review.md` with:
+
+- the recommended selection and loading flow;
+- a compact Swift example for the important steps;
+- permission behavior for picker-only and custom-library cases; and
+- the memory handling required before images enter the grid.

--- a/evals/swiftdata-cloudkit-schema-review/capability.txt
+++ b/evals/swiftdata-cloudkit-schema-review/capability.txt
@@ -1,0 +1,1 @@
+CloudKit schema compatibility

--- a/evals/swiftdata-cloudkit-schema-review/criteria.json
+++ b/evals/swiftdata-cloudkit-schema-review/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Tests SwiftData CloudKit schema restrictions, relationship precision, large data storage, and deployment preparation.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "No uniqueness",
+      "description": "Removes or rejects @Attribute(.unique), #Unique, and equivalent uniqueness constraints for the CloudKit-backed model.",
+      "max_score": 20
+    },
+    {
+      "name": "Optional relationship",
+      "description": "Makes the CloudKit-backed relationship optional rather than requiring the related model.",
+      "max_score": 15
+    },
+    {
+      "name": "Delete rule",
+      "description": "Rejects the deny delete rule for the CloudKit-backed relationship and chooses a compatible rule.",
+      "max_score": 15
+    },
+    {
+      "name": "External blob storage",
+      "description": "Uses @Attribute(.externalStorage) or an equivalent external-storage strategy for the large image Data property.",
+      "max_score": 15
+    },
+    {
+      "name": "Scalar precision",
+      "description": "Does not claim that every scalar property must become optional for SwiftData CloudKit sync.",
+      "max_score": 15
+    },
+    {
+      "name": "Cloud rollout",
+      "description": "Covers the iCloud CloudKit capability, remote-notification mode, and schema promotion or additive rollout concerns.",
+      "max_score": 20
+    }
+  ]
+}

--- a/evals/swiftdata-cloudkit-schema-review/task.md
+++ b/evals/swiftdata-cloudkit-schema-review/task.md
@@ -1,0 +1,17 @@
+# SwiftData Cloud Sync Model Review
+
+## Problem/Feature Description
+
+An iOS app is enabling cloud sync for an existing SwiftData model. The model
+uses a uniqueness constraint for an email address, a required owner
+relationship with a restrictive delete rule, and an image blob stored directly
+on the record. A teammate proposes making every scalar property optional to
+make the schema sync.
+
+Review the model and provide a corrected sketch plus a rollout checklist.
+
+## Output Specification
+
+Create `swiftdata-cloud-schema-review.md` with the incompatible model features,
+a concise corrected model outline, and the required capability and deployment
+considerations.

--- a/evals/swiftdata-coredata-coexistence/capability.txt
+++ b/evals/swiftdata-coredata-coexistence/capability.txt
@@ -1,0 +1,1 @@
+Core Data coexistence boundary

--- a/evals/swiftdata-coredata-coexistence/criteria.json
+++ b/evals/swiftdata-coredata-coexistence/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Tests SwiftData ownership of coexistence work, persistent-store alignment, rename mapping, and precise Codable guidance.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "SwiftData ownership",
+      "description": "Treats Core Data and SwiftData coexistence or migration as SwiftData-owned guidance rather than expanding into a standalone Core Data tutorial.",
+      "max_score": 15
+    },
+    {
+      "name": "Existing store URL",
+      "description": "Points the SwiftData configuration at the existing persistent store URL when sharing or migrating the store.",
+      "max_score": 20
+    },
+    {
+      "name": "Schema alignment",
+      "description": "Requires entity names, property names, types, and relationships to align across the Core Data model and SwiftData @Model classes.",
+      "max_score": 20
+    },
+    {
+      "name": "Rename mapping",
+      "description": "Uses @Attribute(originalName:) or an equivalent persisted-name mapping for the renamed field.",
+      "max_score": 15
+    },
+    {
+      "name": "Codable precision",
+      "description": "Allows compatible Codable structs or enums as SwiftData properties without inventing an unsupported iOS 18-only availability threshold.",
+      "max_score": 15
+    },
+    {
+      "name": "Single writer",
+      "description": "Assigns one persistence stack as the writer for each entity during migration instead of writing the same entity from Core Data and SwiftData concurrently.",
+      "max_score": 15
+    }
+  ]
+}

--- a/evals/swiftdata-coredata-coexistence/task.md
+++ b/evals/swiftdata-coredata-coexistence/task.md
@@ -1,0 +1,17 @@
+# Existing Store Adoption Plan
+
+## Problem/Feature Description
+
+A mature Core Data app wants to introduce SwiftData screens while the existing
+stack remains active. The persisted model includes a renamed field and a value
+type used for addresses. The team wants a short migration and coexistence note,
+not a rewrite of its full Core Data stack.
+
+Explain the ownership boundary and the store and schema alignment work required
+before both paths can safely operate on the same data.
+
+## Output Specification
+
+Create `swiftdata-coexistence-plan.md` containing the routing decision, store
+configuration, model-alignment checklist, rename handling, and a careful note
+about persisted Codable value types.

--- a/evals/swiftdata-predicate-index-review/capability.txt
+++ b/evals/swiftdata-predicate-index-review/capability.txt
@@ -1,0 +1,1 @@
+Predicate and index design

--- a/evals/swiftdata-predicate-index-review/criteria.json
+++ b/evals/swiftdata-predicate-index-review/criteria.json
@@ -1,0 +1,36 @@
+{
+  "context": "Tests predicate capture rules, supported expressions, targeted indexing, and evidence-based migration guidance.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Captured clock",
+      "description": "Captures the current time in a local value before constructing the #Predicate instead of evaluating Date.now directly inside it.",
+      "max_score": 20
+    },
+    {
+      "name": "Supported predicate",
+      "description": "Removes arbitrary model helper calls from #Predicate and uses supported stored-property expressions or post-fetch filtering when necessary.",
+      "max_score": 20
+    },
+    {
+      "name": "Targeted indexes",
+      "description": "Indexes only properties used frequently for filtering or sorting rather than indexing every property.",
+      "max_score": 15
+    },
+    {
+      "name": "Compound index",
+      "description": "Considers a compound index for a repeatedly used filter-and-sort property combination.",
+      "max_score": 15
+    },
+    {
+      "name": "Migration evidence",
+      "description": "Does not guarantee that index changes are migration-free and requires schema or migration testing.",
+      "max_score": 15
+    },
+    {
+      "name": "Query profiling",
+      "description": "Uses profiling, Instruments, or Core Data diagnostics to verify the query and index effect.",
+      "max_score": 15
+    }
+  ]
+}

--- a/evals/swiftdata-predicate-index-review/task.md
+++ b/evals/swiftdata-predicate-index-review/task.md
@@ -1,0 +1,15 @@
+# Slow SwiftData Query Review
+
+## Problem/Feature Description
+
+A trip list filters by destination, excludes expired records using the current
+time, and sorts by start date. Its predicate invokes a convenience method on
+the model. The proposed performance fix is to index every property and assume
+index changes never need migration testing.
+
+Review the query and propose a measured predicate and indexing plan.
+
+## Output Specification
+
+Create `swiftdata-query-review.md` with a corrected predicate sketch, index
+selection guidance, and a verification plan for performance and schema changes.

--- a/skills/accessorysetupkit/SKILL.md
+++ b/skills/accessorysetupkit/SKILL.md
@@ -7,8 +7,7 @@ description: "Discover and configure Bluetooth and Wi-Fi accessories using Acces
 
 Privacy-preserving accessory discovery and setup for Bluetooth and Wi-Fi
 devices. Replaces broad Bluetooth/Wi-Fi permission prompts with a
-system-provided picker that grants per-accessory access with a single tap.
-Available iOS 18+ / Swift 6.3.
+system-provided picker that grants per-accessory access with a single tap (iOS 18+).
 
 After setup, apps continue using CoreBluetooth and NetworkExtension for
 communication. AccessorySetupKit handles only the discovery and authorization
@@ -358,80 +357,13 @@ Migration rules:
 
 ## Common Mistakes
 
-### DON'T: Omit Info.plist keys for Bluetooth discovery
-
-The app crashes if it uses identifiers, names, or services in descriptors that
-are not declared in Info.plist.
-
-```swift
-// WRONG — service UUID not in NSAccessorySetupBluetoothServices
-var descriptor = ASDiscoveryDescriptor()
-descriptor.bluetoothServiceUUID = CBUUID(string: "UNDECLARED-UUID")
-session.showPicker(for: [item]) { _ in }  // Crash
-
-// CORRECT — declare all UUIDs in Info.plist first
-// Info.plist: NSAccessorySetupBluetoothServices = ["ABCD1234-..."]
-var descriptor = ASDiscoveryDescriptor()
-descriptor.bluetoothServiceUUID = CBUUID(string: "ABCD1234-...")
-```
-
-### DON'T: Set both ssid and ssidPrefix
-
-```swift
-// WRONG — crashes at runtime
-var descriptor = ASDiscoveryDescriptor()
-descriptor.ssid = "MyNetwork"
-descriptor.ssidPrefix = "My"  // Cannot set both
-
-// CORRECT — use one or the other
-var descriptor = ASDiscoveryDescriptor()
-descriptor.ssid = "MyNetwork"
-```
-
-### DON'T: Initialize CBCentralManager before migration
-
-```swift
-// WRONG — migration fails, picker does not appear
-let central = CBCentralManager(delegate: self, queue: nil)
-session.showPicker(for: [migrationItem]) { error in
-    // error is non-nil
-}
-
-// CORRECT — wait for .migrationComplete before using CoreBluetooth
-session.activate(on: .main) { event in
-    if event.eventType == .migrationComplete {
-        let central = CBCentralManager(delegate: self, queue: nil)
-    }
-}
-```
-
-### DON'T: Show the picker without user intent
-
-```swift
-// WRONG — picker appears unexpectedly on app launch
-override func viewDidLoad() {
-    super.viewDidLoad()
-    session.showPicker(for: items) { _ in }
-}
-
-// CORRECT — bind picker to a user action
-@IBAction func addAccessoryTapped(_ sender: UIButton) {
-    session.showPicker(for: items) { _ in }
-}
-```
-
-### DON'T: Reuse an invalidated session
-
-```swift
-// WRONG — session is dead after invalidation
-session.showPicker(for: items) { _ in }  // No effect
-
-// CORRECT — create a new session
-let newSession = ASAccessorySession()
-newSession.activate(on: .main) { event in
-    // Handle events
-}
-```
+| Mistake | Fix |
+|---|---|
+| Descriptor identifiers are absent from Info.plist | Declare every Bluetooth service, name, and company identifier before presenting the picker. |
+| Both `ssid` and `ssidPrefix` are set | Choose exactly one matching strategy. |
+| CoreBluetooth starts before migration completes | Wait for `.migrationComplete`, then create `CBCentralManager`. |
+| Picker appears without explicit user intent | Present it only from a user action. |
+| An invalidated session is reused | Create, activate, and retain a new `ASAccessorySession`. |
 
 ## Review Checklist
 

--- a/skills/activitykit/SKILL.md
+++ b/skills/activitykit/SKILL.md
@@ -6,20 +6,12 @@ description: "Implement, review, or improve Live Activities and Dynamic Island e
 # ActivityKit
 
 ActivityKit owns real-time, glanceable Live Activities displayed on the Lock
-Screen and, on supported devices, Dynamic Island. StandBy, CarPlay, and a
-paired Mac can also display Live Activities, but do not blur that core routing:
-ordinary Home Screen/timeline widgets belong in `widgetkit`, and generic APNs
-setup belongs in `push-notifications`. Live Activity push payload shape stays in
-ActivityKit: device-token updates use `apns-push-type: liveactivity` and
-`apns-topic: <bundle-id>.push-type.liveactivity`, while `aps.content-state` must
-decode into the app's actual `ActivityAttributes.ContentState` `Codable` shape.
-Do not assume `Date` or `ClosedRange<Date>` use Unix timestamp
-`lowerBound`/`upperBound` dictionaries unless the Swift model and server
-contract coordinate that encoding. Boundary answers that keep ActivityKit APNs
-payloads, `content-state`, or Live Activity data contracts in scope should
-include these payload-shape invariants even when routing generic APNs setup
-elsewhere. Patterns target iOS 26+ with Swift 6.3;
-modern `ActivityContent` lifecycle examples require iOS 16.2+ unless noted.
+Screen and Dynamic Island. Ordinary timeline widgets belong in `widgetkit`, and
+generic APNs setup belongs in `push-notifications`; ActivityKit owns the Live
+Activity lifecycle and payload contract. `aps.content-state` must decode into
+the exact `ActivityAttributes.ContentState` shape, including any coordinated
+custom date/range encoding. Modern `ActivityContent` lifecycle examples require
+iOS 16.2+ unless noted.
 
 See [references/activitykit-patterns.md](references/activitykit-patterns.md) for complete code patterns including push payload formats, concurrent activities, state observation, and testing.
 
@@ -40,13 +32,16 @@ See [references/activitykit-patterns.md](references/activitykit-patterns.md) for
 
 ### 1. Create a new Live Activity
 
-1. Add `NSSupportsLiveActivities = YES` to the host app's Info.plist.
-2. Define an `ActivityAttributes` struct with a nested `ContentState`.
-3. Create an `ActivityConfiguration` in the widget bundle with Lock Screen
-   content and Dynamic Island closures.
-4. Start the activity with `Activity.request(attributes:content:pushType:)`.
-5. Update with `activity.update(_:)` and end with `activity.end(_:dismissalPolicy:)`.
-6. Forward push tokens to your server for remote updates.
+1. Verify the host app capability and `NSSupportsLiveActivities = YES`.
+2. Define `ActivityAttributes.ContentState`; encode and decode a representative
+   fixture that matches the server payload contract.
+3. Create `ActivityConfiguration` and preview Lock Screen and Dynamic Island
+   states, including stale and terminal content.
+4. Check `ActivityAuthorizationInfo.areActivitiesEnabled`, then request and
+   observe the activity lifecycle.
+5. Exercise local update and every terminal end path.
+6. For remote updates, validate a complete reference payload before registering
+   rotating update or push-to-start tokens with the server.
 
 ### 2. Review existing Live Activity code
 
@@ -335,9 +330,10 @@ Send an HTTP/2 POST to APNs with these headers and JSON body:
 The `aps.alert` payload controls visible alert/banner/sound behavior; priority
 alone does not create an alert.
 
-**Payload body:** Put `timestamp`, `event`, and the full `content-state` inside `aps`. Use `event: "update"` for updates, `event: "end"` plus optional `dismissal-date` for ending, and `event: "start"` with `attributes-type`, `attributes`, `content-state`, and required `alert` for push-to-start. Add `stale-date`, `relevance-score`, or `alert` when appropriate.
-
-The `content-state` JSON must decode into `ActivityAttributes.ContentState`. Use the default synthesized `Codable` key and value shape unless the Swift model declares custom `CodingKeys`; then coordinate those exact keys and value shapes server-side. Do not assume `Date` or `ClosedRange<Date>` values are Unix timestamp dictionaries unless your Swift model explicitly encodes them that way. Mismatched keys or types can prevent ActivityKit from applying the update.
+Put `timestamp`, `event`, and the full `content-state` inside `aps`. Validate
+update, end, and push-to-start bodies against the complete examples in
+[Push-to-Update Payloads](references/activitykit-patterns.md#push-to-update-server-payload-format),
+including the exact `Codable` date/range representation.
 
 ### Push-to-Start
 
@@ -436,12 +432,6 @@ let activity = try Activity.request(
 
 **DON'T:** Assume every device has Dynamic Island.
 **DO:** Design for the Lock Screen as the primary surface; Dynamic Island is supplementary.
-
-**DON'T:** Treat Lock Screen or Dynamic Island Live Activities as ordinary Home Screen/timeline widgets.
-**DO:** Use ActivityKit for the Live Activity lifecycle and those display surfaces; route ordinary Home Screen/timeline widgets to `widgetkit`.
-
-**DON'T:** Reduce Live Activity payload routing to generic `content-state` matching when the prompt involves APNs payloads.
-**DO:** Include the actual `ContentState` `Codable` contract and coordinated `Date`/`ClosedRange<Date>` encoding caveat; route generic APNs auth and registration to `push-notifications`.
 
 **DON'T:** Store sensitive information in ActivityAttributes (visible on Lock Screen).
 **DO:** Keep sensitive data in the app and show only safe-to-display summaries.

--- a/skills/adattributionkit/SKILL.md
+++ b/skills/adattributionkit/SKILL.md
@@ -5,7 +5,7 @@ description: "Measure ad effectiveness with privacy-preserving attribution using
 
 # AdAttributionKit
 
-Privacy-preserving ad attribution for iOS 17.4+ / Swift 6.3. AdAttributionKit
+Privacy-preserving ad attribution for iOS 17.4+. AdAttributionKit
 lets ad networks measure conversions (installs and re-engagements) without
 exposing user-level data. It supports the App Store and alternative
 marketplaces, and interoperates with SKAdNetwork.
@@ -231,25 +231,11 @@ optionally to the advertised app developer) after a conversion event.
 
 ### Conversion windows
 
-Three windows produce up to three postbacks for winning attributions:
-
-| Window | Duration            | Postback delay    |
-|--------|---------------------|-------------------|
-| 1st    | Days 0-2            | 24-48 hours       |
-| 2nd    | Days 3-7            | 24-144 hours      |
-| 3rd    | Days 8-35           | 24-144 hours      |
-
-Tier 0 postbacks only produce the first postback. Nonwinning attributions
-produce only one postback.
+Winning attributions can produce multiple postbacks across conversion windows; lower data tiers and nonwinning attributions disclose less. Load [references/adattributionkit-patterns.md](references/adattributionkit-patterns.md) for the current window and delay matrix.
 
 ### Time windows for events
 
-| Event                          | Time limit                              |
-|--------------------------------|-----------------------------------------|
-| View-through to install        | 24 hours (configurable up to 7 days)    |
-| Click-through to install       | 30 days (configurable down to 1 day)    |
-| Install to first update        | 60 days                                 |
-| Re-engagement to first update  | 2 days                                  |
+Attribution eligibility windows are distinct from conversion/postback windows. Configure and verify view-through, click-through, install-update, and re-engagement limits from the current documentation and the reference; do not merge the two concepts.
 
 ### Lock conversion values early
 
@@ -268,13 +254,7 @@ After locking, the system ignores further updates in that conversion window.
 
 ### Postback data by tier
 
-| Field                        | Tier 0 | Tier 1      | Tier 2      | Tier 3      |
-|------------------------------|--------|-------------|-------------|-------------|
-| `source-identifier` digits   | 2      | 2           | 2-4         | 2-4         |
-| `conversion-value` (fine)    | --     | --          | 1st only    | 1st only    |
-| `coarse-conversion-value`    | --     | 1st only    | 2nd/3rd     | 2nd/3rd     |
-| `publisher-item-identifier`  | --     | --          | --          | Yes         |
-| `country-code`               | --     | --          | --          | Conditional |
+Disclosure grows with the system-assigned data tier. Code and analytics must tolerate absent source digits, fine/coarse conversion values, publisher item ID, and country. The reference owns the detailed tier matrix.
 
 ## Conversion Values
 
@@ -391,82 +371,13 @@ func handleUniversalLink(_ url: URL) {
 
 ## Common Mistakes
 
-### Forgetting to update conversion value on launch
-
-```swift
-// DON'T -- never updating the conversion value
-func appDidLaunch() {
-    // No conversion value update; postback window never starts
-}
-
-// DO -- update conversion value on first launch
-func appDidLaunch() async {
-    try? await Postback.updateConversionValue(0, lockPostback: false)
-}
-```
-
-### Using uppercase ad network IDs
-
-```xml
-<!-- DON'T -->
-<string>Example123.AdAttributionKit</string>
-
-<!-- DO -->
-<string>example123.adattributionkit</string>
-```
-
-### Calling handleTap without a current UIEventAttributionView tap
-
-```swift
-// DON'T -- tap without a current attribution view tap or fresh impression
-try await staleImpression.handleTap()
-// Throws if the tap cannot be validated or the impression expired
-
-// DO -- ensure UIEventAttributionView covers the ad and the impression is fresh
-let attributionView = UIEventAttributionView()
-attributionView.frame = adView.bounds
-adView.addSubview(attributionView)
-// Then handle the tap within 15 minutes after creating the AppImpression
-try await impression.handleTap()
-```
-
-### Ignoring handleTap errors
-
-```swift
-// DON'T
-try? await impression.handleTap()
-
-// DO -- handle specific errors
-do {
-    try await impression.handleTap()
-} catch let error as AdAttributionKitError {
-    switch error {
-    case .impressionExpired:
-        // Impression expired or is stale for click-through handling
-        refreshAdImpression()
-    case .missingAttributionView:
-        // UIEventAttributionView not present
-        break
-    default:
-        print("Attribution error: \(error)")
-    }
-}
-```
-
-### Not responding to postback requests
-
-```swift
-// DON'T -- silently dropping the request
-// The device retries up to 9 times over 9 days on HTTP 500
-
-// DO -- respond with 200 OK immediately
-// Server handler:
-func handlePostback(request: Request) -> Response {
-    // Process asynchronously, respond immediately
-    Task { await processPostback(request.body) }
-    return Response(status: .ok)
-}
-```
+| Mistake | Fix |
+|---|---|
+| First launch never updates conversion value | Call the canonical first-launch update before the intended window elapses. |
+| Ad network ID contains uppercase characters | Use the exact lowercase network identifier. |
+| `handleTap()` uses a stale impression or lacks the current attribution view tap | Cover the ad with `UIEventAttributionView`, keep the impression fresh, and call from the validated tap flow. |
+| Tap errors are discarded | Handle expired-impression and missing-view cases explicitly. |
+| Postback endpoint delays or drops the response | Accept, persist/queue processing, and return the expected success promptly. |
 
 ## Review Checklist
 

--- a/skills/alarmkit/SKILL.md
+++ b/skills/alarmkit/SKILL.md
@@ -381,18 +381,7 @@ Without the extension, alarms may be dismissed unexpectedly or fail to alert,
 though the system can still show a fallback countdown UI in limited cases such
 as after a device restart before first unlock.
 
-When explaining AlarmKit boundaries, say the ownership line explicitly. AlarmKit
-owns alarm authorization, `AlarmManager` scheduling and state, `AlarmAttributes`,
-`AlarmPresentation`, `AlarmPresentationState`, sound, and system Stop/Repeat/Open
-App alarm actions for alarm and timer experiences. The firing alert remains
-system-rendered alarm UI; do not describe AlarmKit as a general custom
-notification UI surface.
-
-Custom countdown or paused alarm UI belongs in a Widget Extension
-`ActivityConfiguration` for the same `AlarmAttributes<Metadata>` type and
-`AlarmPresentationState`. Name the Apple-sourced alarm surfaces together: Lock
-Screen, Dynamic Island, StandBy, and paired Apple Watch. Do not claim Smart Stack
-as an AlarmKit surface.
+AlarmKit owns authorization, `AlarmManager` scheduling/state, alarm attributes and presentation, sound, and system Stop/Repeat/Open App actions. The firing alert is system-rendered; only countdown and paused states use the widget extension's `ActivityConfiguration`. Supported alarm surfaces are Lock Screen, Dynamic Island, StandBy, and paired Apple Watch—not Smart Stack.
 
 Route ordinary Home Screen or Smart Stack widgets, `WidgetFamily` layout choices,
 widget timelines, and `WidgetCenter` reload policy to `widgetkit`. Route non-alarm

--- a/skills/app-clips/SKILL.md
+++ b/skills/app-clips/SKILL.md
@@ -5,7 +5,7 @@ description: "Build iOS App Clips with invocation URLs, App Clip Codes, NFC, QR 
 
 # App Clips
 
-Lightweight, instantly available versions of your iOS app for in-the-moment experiences or demos. Targets iOS 26+ / Swift 6.3 unless noted.
+Build lightweight, instantly available versions of an iOS app for focused in-the-moment experiences or demos.
 
 ## Contents
 

--- a/skills/app-intents/SKILL.md
+++ b/skills/app-intents/SKILL.md
@@ -27,16 +27,7 @@ Shortcuts, Spotlight, widgets, Control Center, and Apple Intelligence.
 
 ### Step 1: Choose the action, boundary, and surface
 
-Start from 1-3 valuable actions people want outside the app, not from the app's
-screen hierarchy. For each action:
-
-- define the smallest domain operation and result the system needs;
-- decide whether it can finish inline or must hand off into a specific app
-  destination;
-- keep the domain mutation in a shared service when inline and open-app variants
-  expose the same operation;
-- use one explicit runtime route for app handoff instead of scattering navigation
-  side effects through intent implementations.
+Start from 1-3 valuable actions people want outside the app, not from its screen hierarchy. Record one design row per action: user goal; inline result or app destination; shared domain operation; parameters and entity query; confirmation/authentication; target surface and protocol. Use one explicit runtime route for app handoff instead of scattering navigation side effects through intents.
 
 Then choose the system feature and protocol that fit that action:
 
@@ -67,7 +58,8 @@ Then choose the system feature and protocol that fit that action:
 
 ### Step 4: Verify
 
-- Build and run in Shortcuts app to confirm parameter resolution.
+- Build and run in the target system surface to confirm discovery, parameter resolution, cancellation, confirmation, authentication, result rendering, and app handoff.
+- If a step fails, reset the fixture, fix the smallest intent/entity/query boundary, and rerun the same action from the same surface before adding another action.
 - Test Siri phrases with the intent preview in Xcode.
 - Confirm `IndexedEntity` instances are indexed in a named Spotlight index.
 - Check widget configuration for `WidgetConfigurationIntent` intents.

--- a/skills/app-store-review/SKILL.md
+++ b/skills/app-store-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: app-store-review
-description: "Prepare for App Store review and prevent rejections. Covers App Store review guidelines, app rejection reasons, PrivacyInfo.xcprivacy privacy manifest requirements, required API reason codes, in-app purchase IAP and StoreKit rules, App Store Guidelines compliance, ATT App Tracking Transparency, EU DMA Digital Markets Act, HIG compliance checklist, app submission preparation, review preparation, metadata requirements, entitlements, widgets, and Live Activities review rules. Use when preparing for App Store submission, fixing rejection reasons, auditing privacy manifests, implementing ATT consent flow, configuring StoreKit IAP, or checking HIG compliance."
+description: "Audits App Store submission readiness and rejection risk across current review guidelines, PrivacyInfo.xcprivacy and required-reason APIs, privacy labels, ATT, StoreKit payments, metadata, entitlements, widgets, and Live Activities. Use when preparing a submission, responding to rejection, reconciling privacy evidence, or separating upload blockers from cleanup."
 ---
 
 # App Store Review Preparation
 
-Guidance for catching App Store rejection risks before submission. Apple's May 2026 fraud-prevention update says App Review evaluated more than 9.1 million submissions in 2025 and rejected more than 2 million, so treat rejection prevention as a normal release-readiness step and re-check official Apple sources before quoting annual statistics.
+Catch App Store rejection risks before submission. Treat policy, SDK, privacy, entitlement, payment, and metadata checks as current release evidence rather than durable facts.
 
 ## Contents
 
@@ -29,6 +29,8 @@ Guidance for catching App Store rejection risks before submission. Apple's May 2
 
 Use this SKILL.md for quick guidance on common rejection reasons and key policies. Use the references for detailed checklists and privacy manifest specifics.
 
+Start every audit by fetching the current App Review Guidelines, Upcoming Requirements, screenshot specifications, required-reason API documentation, and applicable storefront/entitlement payment rules. Record the checked date and source beside each release blocker. Then archive-build and validate the exact submission, separate blockers from cleanup, fix one class of evidence mismatch, and rerun the same checks against the rebuilt archive.
+
 For prompts about keywords, screenshot captions, product-page metadata, or metadata rejection risk, answer from a compliance angle and explicitly defer keyword research, ranking strategy, conversion optimization, screenshot ordering, and A/B testing to `app-store-optimization`. Keep App Review metadata guidance limited to accuracy, field limits, misleading-content risk, and screenshot compliance. Always surface the rejection-prone format checks: app name 30 characters, subtitle 30 characters, keyword field 100 characters with comma-separated keywords and no spaces after commas, screenshots showing actual app UI, 6.9-inch iPhone screenshots as the primary current iPhone set, and 13-inch iPad screenshots when the app runs on iPad.
 
 For full submission readiness audits, separate blocking upload/review issues from ordinary cleanup. Treat Xcode 26+ with the relevant platform SDK 26+ as a blocking App Store Connect upload requirement after April 28, 2026. Cross-check privacy manifests, App Store privacy nutrition labels, privacy policy, ATT state, runtime network behavior, and SDK behavior against each other; the declarations and observed behavior must align.
@@ -45,43 +47,14 @@ Escalate these as blockers before ordinary cleanup:
 
 ## Top Rejection Reasons and How to Avoid Them
 
-### Guideline 2.1 -- App Completeness
+| Guideline risk | Release evidence |
+|---|---|
+| 2.1 completeness | No placeholders, broken/empty flows, inaccessible hardware-only features, or login gates without working demo credentials and review notes. |
+| 2.3 metadata | App name, category, description, keywords, and screenshots accurately represent the submitted binary and actual UI. |
+| 4.2 minimum functionality | The app provides meaningful app-specific value beyond a thin website or trivial duplication of system behavior. |
+| 2.5.1 software requirements | Archive uses public APIs, meets the current Xcode/SDK upload floor, and does not download code that changes reviewed functionality outside documented exceptions. |
 
-The app must be fully functional when reviewed. Apple rejects for:
-
-- Placeholder content, lorem ipsum, or test data visible anywhere
-- Broken links or empty screens
-- Features behind logins without demo credentials provided in App Review notes
-- Features that require hardware Apple does not have access to
-
-**Prevention:**
-- Provide demo account credentials in the App Review Information notes field in App Store Connect
-- Walk through every screen and verify real content is present
-- Test all flows end-to-end, including edge cases like empty states and error conditions
-
-### Guideline 2.3 -- Accurate Metadata
-
-- App name must match what the app actually does
-- Screenshots must show the actual app UI, not marketing renders or mockups
-- Description must not contain prices (they vary by region)
-- No references to other platforms ("Also available on Android")
-- Keywords must be relevant -- no competitor names or unrelated terms
-- Category must match the app's primary function
-
-### Guideline 4.2 -- Minimum Functionality
-
-Apple rejects apps that are too simple or are just websites in a wrapper:
-
-- WKWebView-only apps are rejected unless they add meaningful native functionality
-- Single-feature apps may be rejected if the feature is better suited as part of another app
-- Apps that duplicate built-in iOS functionality without significant improvement are rejected
-
-### Guideline 2.5.1 -- Software Requirements
-
-- Must use public APIs only -- private API usage is an instant rejection
-- As of April 28, 2026, uploads to App Store Connect must be built with Xcode 26 or later using the relevant platform SDK 26 or later
-- Deployment target support is a product and compatibility decision, not an App Review rule
-- Must not download or execute code that introduces or changes app features or functionality after review, except where Apple guidelines and agreements explicitly allow interpreted code
+Verify these against the current guidelines and the exact archive; do not carry version or screenshot requirements forward from an older release checklist.
 
 ## PrivacyInfo.xcprivacy -- Privacy Manifest Requirements
 
@@ -106,38 +79,7 @@ A privacy manifest is required when your app code, an executable, a dynamic libr
 
 ## In-App Purchase and StoreKit Rules (Guideline 3.1.1)
 
-IAP rules are strict and heavily enforced.
-
-### What Generally Requires Apple IAP
-
-Digital content, features, subscriptions, and services unlocked in the app generally must use Apple's In-App Purchase system unless a specific App Review guideline exception, regional rule, or approved entitlement applies. Remove external purchase paths unless the current rules or an approved entitlement allow them:
-
-- Premium features or content unlocks
-- Subscriptions to app functionality
-- Virtual currency, coins, gems
-- Ad removal
-- Digital tips or donations
-
-### What Does NOT Require IAP
-
-- Physical products (e-commerce)
-- Ride-sharing, food delivery, real-world services
-- One-to-one services (tutoring, consulting booked through the app)
-- Enterprise/B2B apps distributed through Apple Business Manager
-
-### Subscription Display Requirements
-
-- Price, duration, and auto-renewal terms must be clearly displayed before purchase
-- Free trials must clearly show trial duration, post-trial price, billing frequency, auto-renewal, and cancellation terms before purchase
-- Remove external purchase links, buttons, calls to action, or purchase paths for digital goods unless the current storefront rules or an approved entitlement explicitly allow them
-- "Reader" apps (Netflix, Spotify) may link to external sign-up but cannot offer IAP bypass
-
-### StoreKit Implementation Checklist
-
-- Consumables, non-consumables, and subscriptions must be correctly categorized in App Store Connect
-- Restore purchases functionality must be present and working
-- Transaction verification should use StoreKit 2 `Transaction.currentEntitlements` or server-side validation
-- Handle interrupted purchases, deferred transactions, and ask-to-buy gracefully
+Digital goods, features, subscriptions, virtual currency, ad removal, and digital tips generally require IAP unless a current guideline exception, storefront rule, or approved entitlement applies. Physical goods and real-world services use their ordinary payment flow. Before purchase, show price, duration, renewal/trial terms, billing frequency, and cancellation terms; verify product classification, restoration, entitlement verification, deferred/interrupted purchases, and Ask to Buy. Load `storekit` for implementation and re-check current regional/external-link rules before labeling a path compliant.
 
 ## HIG Compliance Checklist
 

--- a/skills/apple-on-device-ai/SKILL.md
+++ b/skills/apple-on-device-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-on-device-ai
-description: "Integrate on-device AI using Foundation Models framework, Core ML, and open-source LLM runtimes on Apple Silicon. Covers Foundation Models (LanguageModelSession, @Generable, @Guide, SystemLanguageModel, structured output, tool calling), Core ML (coremltools, model conversion, quantization, palettization, pruning, Neural Engine, MLTensor), MLX Swift (transformer inference, unified memory), and llama.cpp (GGUF, cross-platform LLM). Use when building tool-calling AI features, working with guided generation schemas, converting models, or running on-device inference."
+description: "Build private, on-device AI features on iPhone, iPad, and Mac with Foundation Models, Core ML, MLX Swift, or llama.cpp. Use when choosing an Apple-local model runtime, building an Apple Intelligence chatbot or tool-calling feature, running an LLM on Apple Silicon, converting or compressing a Python model for Core ML, or comparing on-device inference backends. For Swift Core ML loading and prediction code, use the coreml skill."
 ---
 
 # On-Device AI for Apple Platforms
@@ -91,17 +91,9 @@ deployments needing broad device support.
 
 ## Apple Foundation Models Overview
 
-On-device language model optimized for Apple Silicon. Available on devices
-supporting Apple Intelligence (iOS 26+, macOS 26+).
-
-- Token budget covers input + output; check `contextSize` for the limit
-- Resolve locale before generation by checking `supportsLocale(_:)` against
-  `Locale.current` and preferred fallbacks; do not raw-match `supportedLanguages`
-- Guardrails always enforced, cannot be disabled
-
-### Availability Checking (Required)
-
-Always check before using. Never crash on unavailability.
+Use the system language model for short generation, summarization, tagging,
+structured output, and tool-augmented tasks on Apple Intelligence devices. Gate
+every entry point before creating a session:
 
 ```swift
 import FoundationModels
@@ -124,188 +116,29 @@ case .unavailable(let reason):
 }
 ```
 
-### Session Management
+Then create a session and keep its shared context budget small:
 
 ```swift
-// Basic session
-let session = LanguageModelSession()
-
-// Session with instructions
 let session = LanguageModelSession {
     "You are a helpful cooking assistant."
 }
-
-// Session with tools
-let session = LanguageModelSession(
-    tools: [weatherTool, recipeTool]
-) {
-    "You are a helpful assistant with access to tools."
-}
+session.prewarm()
+let response = try await session.respond(to: "Suggest a quick pasta recipe")
 ```
 
-Key rules:
-- Sessions are stateful -- multi-turn conversations maintain context automatically
-- One request at a time per session (check `session.isResponding`)
-- Call `session.prewarm()` before user interaction for faster first response
-- Save/restore transcripts: `LanguageModelSession(model: model, tools: [], transcript: savedTranscript)`
+Required guardrails:
 
-### Structured Output with `@Generable`
+- Sessions are stateful and accept one request at a time; serialize access and
+  check `isResponding` before issuing another response.
+- Instructions, tools, schemas, prompts, transcripts, and output share the
+  context window. Register only necessary tools and keep schemas compact.
+- Resolve the locale with `supportsLocale(_:)`; do not raw-match language lists.
+- Keep untrusted user content in prompts, never instructions. System guardrails
+  remain active, so handle refusal and other generation errors with fallback UI.
 
-The `@Generable` macro creates compile-time schemas for type-safe output:
-
-```swift
-@Generable
-struct Recipe {
-    @Guide(description: "The recipe name")
-    var name: String
-
-    @Guide(description: "Cooking steps", .count(3))
-    var steps: [String]
-
-    @Guide(description: "Prep time in minutes", .range(1...120))
-    var prepTime: Int
-}
-
-let response = try await session.respond(
-    to: "Suggest a quick pasta recipe",
-    generating: Recipe.self
-)
-print(response.content.name)
-```
-
-#### `@Guide` Constraints
-
-| Constraint | Purpose |
-|---|---|
-| `description:` | Natural language hint for generation |
-| `.anyOf([values])` | Restrict to enumerated string values |
-| `.count(n)` | Fixed array length |
-| `.range(min...max)` | Numeric range |
-| `.minimum(n)` / `.maximum(n)` | One-sided numeric bound |
-| `.minimumCount(n)` / `.maximumCount(n)` | Array length bounds |
-| `.constant(value)` | Always returns this value |
-| `.pattern(regex)` | String format enforcement |
-| `.element(guide)` | Guide applied to each array element |
-
-Properties generate in declaration order. Place foundational data before
-dependent data for better results.
-
-### Streaming Structured Output
-
-```swift
-let stream = session.streamResponse(
-    to: "Suggest a recipe",
-    generating: Recipe.self
-)
-for try await snapshot in stream {
-    // snapshot.content is Recipe.PartiallyGenerated (all properties optional)
-    if let name = snapshot.content.name { updateNameLabel(name) }
-}
-```
-
-### Tool Calling
-
-```swift
-struct WeatherTool: Tool {
-    let name = "weather"
-    let description = "Get current weather for a city."
-
-    @Generable
-    struct Arguments {
-        @Guide(description: "The city name")
-        var city: String
-    }
-
-    func call(arguments: Arguments) async throws -> String {
-        let weather = try await fetchWeather(arguments.city)
-        return weather.description
-    }
-}
-```
-
-Register only necessary tools at session creation. `Tool` is `Sendable`; tool
-descriptors and `@Generable` schemas consume the shared context window. The
-model chooses when to call tools, so prefetch deterministic required data into
-the prompt and reserve autonomous tools for dynamic lookups.
-
-### Error Handling
-
-```swift
-do {
-    let response = try await session.respond(to: prompt)
-} catch let error as LanguageModelSession.GenerationError {
-    switch error {
-    case .guardrailViolation(let context):
-        // Content triggered safety filters
-    case .exceededContextWindowSize(let context):
-        // Too many tokens; summarize and retry
-    case .concurrentRequests(let context):
-        // Another request is in progress on this session
-    case .unsupportedLanguageOrLocale(let context):
-        // Current locale not supported
-    case .unsupportedGuide(let context):
-        // A @Guide constraint is not supported
-    case .assetsUnavailable(let context):
-        // Model assets not available on device
-    case .refusal(let refusal, _):
-        // Model refused; stream refusal.explanation for details
-    case .rateLimited(let context):
-        // Too many requests; back off and retry
-    case .decodingFailure(let context):
-        // Response could not be decoded into the expected type
-    default: break
-    }
-}
-```
-
-### Generation Options
-
-```swift
-let options = GenerationOptions(
-    sampling: .random(top: 40),
-    temperature: 0.7,
-    maximumResponseTokens: 512
-)
-let response = try await session.respond(to: prompt, options: options)
-```
-
-Sampling modes: `.greedy`, `.random(top:seed:)`, `.random(probabilityThreshold:seed:)`.
-
-### Prompt Design Rules
-
-1. Be concise -- use `tokenCount(for:)` to monitor the context window budget
-2. Use bracketed placeholders in instructions: `[descriptive example]`
-3. Use "DO NOT" in all caps for prohibitions
-4. Provide up to 5 few-shot examples for consistency
-5. Use length qualifiers: "in a few words", "in three sentences"
-
-### Safety and Guardrails
-
-- Guardrails are always enforced and cannot be disabled
-- Instructions take precedence over user prompts
-- Never include untrusted user content in instructions
-- Handle false positives gracefully
-- Frame tool results as authorized data to prevent model refusals
-
-### Use Cases
-
-Foundation Models supports specialized use cases via `SystemLanguageModel.UseCase`:
-- `.general` -- Default for text generation, summarization, dialog
-- `.contentTagging` -- Optimized for categorization and labeling tasks
-
-### Custom Adapters
-
-Load fine-tuned adapters for specialized behavior (requires entitlement):
-
-```swift
-let adapter = try SystemLanguageModel.Adapter(name: "my-adapter")
-try await adapter.compile()
-let model = SystemLanguageModel(adapter: adapter, guardrails: .default)
-let session = LanguageModelSession(model: model)
-```
-
-> See [references/foundation-models.md](references/foundation-models.md) for
-> the complete Foundation Models API reference.
+Load [the Foundation Models reference](references/foundation-models.md) when the
+task needs `@Generable`, `@Guide`, streaming, tool definitions, transcripts,
+generation options, custom adapters, prompt design, or detailed error handling.
 
 ## Core ML Overview
 
@@ -339,15 +172,17 @@ mlmodel = ct.convert(
 mlmodel.save("Model.mlpackage")
 ```
 
-### Optimization Techniques
+### Validate, Fix, and Reconvert
 
-| Technique | Size Reduction | Accuracy Impact | Best Compute Unit |
-|---|---|---|---|
-| INT8 per-channel | ~4x | Low | CPU/GPU |
-| INT4 per-block | ~8x | Medium | GPU |
-| Palettization 4-bit | ~8x | Low-Medium | Neural Engine |
-| W8A8 (weights+activations) | ~4x | Low | ANE (A17 Pro/M4+) |
-| Pruning 75% | ~4x | Medium | CPU/ANE |
+1. Freeze representative source-model fixtures and acceptable output/task
+   tolerances before conversion.
+2. Convert, then run the same fixtures through the source and Core ML models.
+3. If output parity or task metrics miss tolerance, inspect shapes, operators,
+   precision, and preprocessing; fix the conversion and rerun the fixtures.
+4. Compress only after the uncompressed model passes. Revalidate accuracy after
+   each compression change and undo or tune changes that miss the threshold.
+5. Profile the passing model on physical target devices, then repeat until
+   correctness, latency, memory, and package-size targets all pass.
 
 ### Boundary with `coreml`
 
@@ -458,14 +293,16 @@ unless product explicitly opts into a nonlocal fallback.
    request at a time. Check `session.isResponding` or serialize access.
 5. **Untrusted content in instructions.** User input placed in the instructions
    parameter bypasses guardrail boundaries. Keep user content in the prompt.
-6. **Forgetting `model.eval()` before Core ML tracing.** PyTorch models must be
+6. **Skipping conversion parity checks.** Compare the source and Core ML model
+   on fixed fixtures, then fix and reconvert before compressing or shipping.
+7. **Forgetting `model.eval()` before Core ML tracing.** PyTorch models must be
    in eval mode before `torch.jit.trace`. Training-mode artifacts corrupt output.
-7. **Using neuralnetwork format.** Always use `mlprogram` (.mlpackage) for new
+8. **Using neuralnetwork format.** Always use `mlprogram` (.mlpackage) for new
    Core ML models. The legacy neuralnetwork format is deprecated.
-8. **Exceeding 60% RAM on iOS (MLX Swift).** Large models cause OOM kills.
-9. **Trusting MLX simulator results.** Validate Metal-dependent behavior on
+9. **Exceeding 60% RAM on iOS (MLX Swift).** Large models cause OOM kills.
+10. **Trusting MLX simulator results.** Validate Metal-dependent behavior on
    physical devices; Simulator is only a UI/control-flow smoke test.
-10. **Not clearing MLX caches.** Pair model unload with `Memory.clearCache()`.
+11. **Not clearing MLX caches.** Pair model unload with `Memory.clearCache()`.
 
 ## Review Checklist
 
@@ -476,7 +313,8 @@ unless product explicitly opts into a nonlocal fallback.
 - [ ] Foundation Models: `@Generable` properties in logical generation order
 - [ ] Foundation Models: token budget accounted for (check `contextSize`)
 - [ ] Core ML: model format is mlprogram (.mlpackage) for iOS 15+
-- [ ] Core ML: conversion, deployment target, and compression validated
+- [ ] Core ML: source/Core ML parity passes fixed fixtures and task tolerances
+- [ ] Core ML: compressed model revalidated and profiled on physical targets
 - [ ] MLX Swift: model size appropriate for target device RAM
 - [ ] MLX Swift: cache limits set, caches cleared, models unloaded
 - [ ] All model access serialized through coordinator actor

--- a/skills/audioaccessorykit/SKILL.md
+++ b/skills/audioaccessorykit/SKILL.md
@@ -113,38 +113,20 @@ the correct device based on placement and connected sources.
 
 ### Enabling Audio Switching
 
-Declare the `.audioSwitching` capability in the registration configuration:
-
-```swift
-let configuration = AccessoryControlDevice.Configuration(
-    deviceCapabilities: [.audioSwitching]
-)
-
-try await AccessoryControlDevice.register(accessory, configuration)
-```
-
-For Apple's automatic switching workflow, include both `.audioSwitching` and
-`.placement` when the accessory can report placement:
-
-```swift
-let configuration = AccessoryControlDevice.Configuration(
-    devicePlacement: .offHead,
-    deviceCapabilities: [.audioSwitching, .placement]
-)
-
-try await AccessoryControlDevice.register(accessory, configuration)
-```
+Declare `.audioSwitching` during the canonical registration flow above. Include
+`.placement` and an initial placement only when the accessory can report ongoing
+placement changes.
 
 ### Capabilities
 
-`AccessoryControlDevice.Capabilities` is an option set with two members:
+Automatic switching commonly uses these `AccessoryControlDevice.Capabilities`:
 
 | Capability | Purpose |
 |---|---|
 | `.audioSwitching` | Device supports automatic audio switching |
 | `.placement` | Device can report its physical placement |
 
-Both capabilities can be combined. Do not declare `.placement` unless the
+Combine capabilities as needed. Do not declare `.placement` unless the
 accessory can keep the system updated with real placement state.
 
 ## Device Placement
@@ -167,12 +149,10 @@ position change.
 ### Updating Placement
 
 ```swift
-let device = try AccessoryControlDevice.current(for: accessory)
-var config = device.configuration
-
 config.devicePlacement = .inEar
-try await device.update(config)
 ```
+
+Apply this mutation within the canonical current→copy→update sequence above.
 
 Common transitions:
 
@@ -191,24 +171,20 @@ the system route audio from the appropriate source.
 Provide the Bluetooth address of connected devices as `Data`:
 
 ```swift
-let device = try AccessoryControlDevice.current(for: accessory)
-var config = device.configuration
-
 let primaryBTAddress = Data([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC])
 config.primaryAudioSourceDeviceIdentifier = primaryBTAddress
 
 let secondaryBTAddress = Data([0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45])
 config.secondaryAudioSourceDeviceIdentifier = secondaryBTAddress
-
-try await device.update(config)
 ```
 
 Update these identifiers when the Bluetooth connection state changes (new
-device connects, existing device disconnects).
+device connects, existing device disconnects), then call the canonical
+`update(_:)` sequence.
 
 ### Configuration Properties
 
-`AccessoryControlDevice.Configuration` contains all configurable state:
+Automatic switching uses these configuration fields:
 
 | Property | Type | Purpose |
 |---|---|---|
@@ -304,55 +280,17 @@ do {
 
 ### DON'T: Register before pairing with AccessorySetupKit
 
-```swift
-// WRONG -- no ASAccessory from a completed AccessorySetupKit pairing
-try await AccessoryControlDevice.register(unknownAccessory, configuration)
-
-// CORRECT -- use the ASAccessory from a completed pairing session
-session.activate(on: .main) { event in
-    if event.eventType == .accessoryAdded, let accessory = event.accessory {
-        Task {
-            let configuration = AccessoryControlDevice.Configuration(
-                deviceCapabilities: [.audioSwitching]
-            )
-            try await AccessoryControlDevice.register(accessory, configuration)
-        }
-    }
-}
-```
+Register only the `ASAccessory` returned by a completed AccessorySetupKit pairing.
 
 ### DON'T: Declare placement capability without updating placement
 
-```swift
-// WRONG -- registers placement but never updates it
-let registration = AccessoryControlDevice.Configuration(
-    deviceCapabilities: [.audioSwitching, .placement]
-)
-try await AccessoryControlDevice.register(accessory, registration)
-// System never receives placement data, reducing switching accuracy
-
-// CORRECT -- extension updates placement when state changes
-let device = try AccessoryControlDevice.current(for: accessory)
-var config = device.configuration
-config.devicePlacement = .offHead
-try await device.update(config)
-```
+If registration declares `.placement`, the extension must update placement on
+every detected transition using the canonical update sequence.
 
 ### DON'T: Ignore connection state changes for multi-device accessories
 
-```swift
-// WRONG -- set audio source identifiers once and never update
-config.primaryAudioSourceDeviceIdentifier = someAddress
-try await device.update(config)
-// Device disconnects, but system still thinks it's the primary source
-
-// CORRECT -- update identifiers when connections change
-func onDeviceDisconnected() {
-    var config = device.configuration
-    config.primaryAudioSourceDeviceIdentifier = nil
-    Task { try await device.update(config) }
-}
-```
+Clear or replace primary and secondary source identifiers whenever Bluetooth
+connections change; stale identifiers reduce switching accuracy.
 
 ### DON'T: Forget to handle the invalidated error
 
@@ -390,9 +328,9 @@ do {
 - [AudioAccessoryKit framework](https://sosumi.ai/documentation/audioaccessorykit)
 - [Supporting automatic audio switching](https://sosumi.ai/documentation/audioaccessorykit/supporting-automatic-audio-switching)
 - [AccessoryControlDevice](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice)
-- [AccessoryControlDevice.register(_:_:)](<https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/register(_:_:)>)
-- [AccessoryControlDevice.current(for:)](<https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/current(for:)>)
-- [AccessoryControlDevice.update(_:)](<https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/update(_:)>)
+- [AccessoryControlDevice registration](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/register%28_%3A_%3A%29)
+- [AccessoryControlDevice lookup](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/current%28for%3A%29)
+- [AccessoryControlDevice update](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/update%28_%3A%29)
 - [AccessoryControlDevice.Configuration](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/configuration-swift.struct)
 - [AccessoryControlDevice.Capabilities](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/capabilities)
 - [AccessoryControlDevice.Placement](https://sosumi.ai/documentation/audioaccessorykit/accessorycontroldevice/placement)

--- a/skills/browserenginekit/SKILL.md
+++ b/skills/browserenginekit/SKILL.md
@@ -357,34 +357,23 @@ longer needs. Use the latest available revision for the strongest restrictions.
 
 ### JIT Compilation
 
-Web content extensions that JIT-compile JavaScript toggle memory between
-writable and executable states. Use the `BE_JIT_WRITE_PROTECT_TAG` from
-BrowserEngineCore:
+Web content extensions that JIT-compile JavaScript must transition pages with BrowserEngineKit's witnessed APIs:
 
 ```swift
 import BrowserEngineCore
 
-// BE_JIT_WRITE_PROTECT_TAG is used with pthread_jit_write_protect_np
-// to control JIT memory page permissions
+be_memory_inline_jit_restrict_rwx_to_rw_with_witness(...)
+// write generated code
+be_memory_inline_jit_restrict_rwx_to_rx_with_witness(...)
 ```
 
 Requires the `com.apple.security.cs.allow-jit` and
 `com.apple.developer.kernel.extended-virtual-addressing` entitlements on
-the web content extension only.
+the web content extension only. If an implementation instead uses `pthread_jit_write_with_callback_np`, it also needs the JIT write allowlist entitlement; do not present `BE_JIT_WRITE_PROTECT_TAG` alone as a complete protection strategy.
 
 ### arm64e Requirement
 
-All executables (host app and extensions) must be built with the `arm64e`
-instruction set for distribution. Build as a universal binary to also support
-`arm64` iPads.
-
-In Xcode build settings or xcconfig:
-
-```
-ARCHS[sdk=iphoneos*]=arm64e
-```
-
-Do not use `arm64e` for Simulator targets.
+Distribution builds must satisfy the current alternative-browser entitlement profile's device architecture, PAC, and MIE requirements. Keep the host and extension configuration consistent, include the required device slices, and test the signed archive on eligible devices. Embedded engines differ: they are arm64-only and cannot use JIT. Do not force `arm64e` onto Simulator builds or copy a one-line `ARCHS` override that drops required slices.
 
 ## Downloads
 

--- a/skills/callkit/SKILL.md
+++ b/skills/callkit/SKILL.md
@@ -8,7 +8,6 @@ description: "Implement VoIP calling with CallKit and PushKit. Use when building
 Build VoIP calling features that integrate with the native iOS call UI using
 CallKit and PushKit. Covers incoming/outgoing call flows, VoIP push
 registration, audio session coordination, and call directory extensions.
-Targets Swift 6.3 / iOS 26+.
 
 ## Contents
 
@@ -392,65 +391,16 @@ auth-key rotation and normal remote-notification setup to push-notifications.
 
 ## Common Mistakes
 
-### DON'T: Fail to report a required call on VoIP push receipt
+| Mistake | Fix |
+|---|---|
+| Required VoIP push is treated as data-only | Apply the version-specific report rule, report before completion, then invoke the PushKit completion handler. |
+| Answer action is fulfilled before media/server readiness | Keep it pending while connecting; fulfill on readiness or fail and report `.failed`. |
+| Media starts before `provider(_:didActivate:)` | Prepare earlier if needed, but start only after activation and stop on deactivation/reset. |
+| An action path never calls `fulfill()` or `fail()` | Give success, cancellation, timeout, and network-error paths one terminal action. |
+| Token refresh is ignored | Send every `didUpdate pushCredentials` token to the server. |
+| Call Directory performs per-call networking | Preload sorted entries and reload the extension. |
 
-Follow the PushKit report rules above: iOS 13 SDK+ apps must report
-report-required VoIP call pushes before completion, and on iOS 26.4+
-`PKVoIPPushMetadata.mustReport` identifies which pushes are required. Missing a
-required report can terminate the app; repeated failures may stop VoIP delivery.
-
-Do not treat a required VoIP push as a data-only notification. Report the call
-to CallKit and call the PushKit completion handler from the report completion.
-
-### DON'T: Fulfill answer before the call is connected
-
-When the user answers before your app has established the server/media
-connection, leave the `CXAnswerCallAction` pending while connecting. Fulfill it
-after the call is ready; if connection fails, fail the action and report the
-call ended with `.failed`.
-
-### DON'T: Start audio before CallKit activates the session
-
-Starting your audio engine before `provider(_:didActivate:)` causes silence
-or immediate deactivation. CallKit manages session priority with the system.
-
-Prepare audio in the answer/start action if needed, then start media only from
-`provider(_:didActivate:)`.
-
-For iOS 26 call translation, set `CXProviderConfiguration.supportsAudioTranslation`
-when your service supports it and handle `CXSetTranslatingCallAction`. If a
-person mutes during a translated call, mute app input with
-`CXSetMutedCallAction`; do not deactivate upstream audio that translated audio
-depends on.
-
-For encrypted VoIP metadata, use `CXProvider.reportNewIncomingVoIPPushPayload`
-only from a notification service extension when the server cannot determine
-whether encrypted content is a VoIP call or other data. That path requires the
-`com.apple.developer.usernotifications.filtering` entitlement; otherwise send a
-normal PushKit VoIP push.
-
-### DON'T: Forget to call action.fulfill() or action.fail()
-
-Failing to fulfill or fail an action leaves the call in a limbo state and
-triggers the timeout handler.
-
-Every provider action path must eventually call `fulfill()` or `fail()`,
-including network-error and cancellation paths.
-
-### DON'T: Ignore push token refresh
-
-The VoIP push token can change at any time. If your server has a stale token,
-pushes silently fail and incoming calls never arrive.
-
-Send the token to your server every time `didUpdate pushCredentials` fires,
-not just during first-run onboarding.
-
-### DON'T: Use Call Directory for per-call lookup
-
-Call Directory extensions provide preloaded caller ID and blocking data. They
-cannot ask a web service for the incoming caller during call presentation.
-Fetch or generate the dataset ahead of time, reload the extension, and add
-entries in sorted sequential order.
+Keep translation behavior and encrypted-metadata filtering in their feature sections/reference; do not mix those entitlements into the basic audio lifecycle rule.
 
 ## Review Checklist
 

--- a/skills/cloudkit/SKILL.md
+++ b/skills/cloudkit/SKILL.md
@@ -7,12 +7,12 @@ description: "Implement, review, or improve CloudKit and iCloud sync in iOS/macO
 
 Sync data across devices using CloudKit, iCloud key-value storage, and iCloud
 Drive. Covers container setup, record CRUD, queries, subscriptions, CKSyncEngine,
-SwiftData integration, conflict resolution, and error handling. Targets iOS 26+
-with Swift 6.3; older availability noted where relevant.
+SwiftData integration, conflict resolution, and error handling.
 
 ## Contents
 
 - [Container and Database Setup](#container-and-database-setup)
+- [Workflow](#workflow)
 - [CKRecord CRUD](#ckrecord-crud)
 - [CKQuery](#ckquery)
 - [CKSubscription](#cksubscription)
@@ -25,6 +25,16 @@ with Swift 6.3; older availability noted where relevant.
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
 - [References](#references)
+
+## Workflow
+
+1. Choose the database scope and sync owner; verify capability, container, account status, schema, and environment before writing records.
+2. Make a local change durable, enqueue it, then let subscriptions or `CKSyncEngine` drive remote work rather than polling.
+3. Persist change tokens or sync-engine state after successful application.
+4. Test offline edits, partial failure, rate limiting, token expiry, conflict, account loss, zone deletion, and relaunch.
+5. On failure, classify the `CKError`, restore the affected fixture or queue item, apply the documented retry/reset/merge action, and rerun the same scenario. Never restart a full sync blindly after partial success.
+
+Load [references/cloudkit-patterns.md](references/cloudkit-patterns.md) for incremental zone changes, shares, assets, batch operations, and Dashboard procedures.
 
 ## Container and Database Setup
 
@@ -429,43 +439,14 @@ func resolveConflict(_ error: CKError) {
 
 ## Common Mistakes
 
-**DON'T:** Perform sync operations without checking account status.
-**DO:** Check `CKContainer.accountStatus()` first; handle `.noAccount`.
-```swift
-// WRONG
-try await privateDB.save(record)
-// CORRECT
-guard try await CKContainer.default().accountStatus() == .available
-else { throw SyncError.noiCloudAccount }
-try await privateDB.save(record)
-```
-
-**DON'T:** Ignore `.serverRecordChanged` errors.
-**DO:** Implement three-way merge using ancestor, client, and server records.
-
-**DON'T:** Store user-specific data in the public database.
-**DO:** Use private database for personal data; public only for app-wide content.
-
-**DON'T:** Poll for changes on a timer.
-**DO:** Use `CKDatabaseSubscription` or `CKSyncEngine` for push-based sync.
-```swift
-// WRONG
-Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in fetchAll() }
-// CORRECT
-let sub = CKDatabaseSubscription(subscriptionID: "db-changes")
-sub.notificationInfo = CKSubscription.NotificationInfo()
-sub.notificationInfo?.shouldSendContentAvailable = true
-try await privateDB.save(sub)
-```
-
-**DON'T:** Retry immediately on rate limiting.
-**DO:** Use `CKError.retryAfterSeconds` to wait the required duration.
-
-**DON'T:** Assume `CKSyncEngine` handles `.serverRecordChanged` conflicts for you.
-**DO:** Resolve `failedRecordSaves` with a three-way merge, then reschedule the save.
-
-**DON'T:** Pass nil change token on every fetch.
-**DO:** Persist change tokens to disk and supply them on subsequent fetches.
+| Mistake | Fix |
+|---|---|
+| Syncing without an account gate | Check `accountStatus()` and model `.noAccount` as a user-visible state. |
+| Personal data in the public database | Use private scope for user data; public scope is app-wide content. |
+| Timer polling | Use database subscriptions or `CKSyncEngine`. |
+| Immediate retry after throttling | Respect `retryAfterSeconds` and preserve pending work. |
+| Assuming the engine resolves conflicts | Three-way merge `failedRecordSaves`, then reschedule the save. |
+| Starting every fetch with a nil token | Persist tokens/state; reset only on the documented expiry path. |
 
 ## Review Checklist
 

--- a/skills/core-bluetooth/SKILL.md
+++ b/skills/core-bluetooth/SKILL.md
@@ -8,7 +8,6 @@ description: "Build direct Bluetooth Low Energy workflows with Core Bluetooth. U
 Scan for, connect to, and exchange data with Bluetooth Low Energy (BLE) devices.
 Covers the central role (scanning and connecting to peripherals), the peripheral
 role (advertising services), background modes, and state restoration.
-Targets Swift 6.3 / iOS 26+.
 Use `accessorysetupkit` for privacy-preserving accessory discovery and setup;
 use this skill for direct Core Bluetooth GATT communication.
 
@@ -380,82 +379,13 @@ func peripheralManager(
 
 ## Common Mistakes
 
-### DON'T: Scan or connect before poweredOn
-
-```swift
-// WRONG: Scanning immediately -- manager may not be ready
-let manager = CBCentralManager(delegate: self, queue: nil)
-manager.scanForPeripherals(withServices: nil) // May silently fail
-
-// CORRECT: Wait for poweredOn in the delegate
-func centralManagerDidUpdateState(_ central: CBCentralManager) {
-    if central.state == .poweredOn {
-        central.scanForPeripherals(withServices: [serviceUUID])
-    }
-}
-```
-
-### DON'T: Lose the peripheral reference
-
-Core Bluetooth does not retain discovered peripherals. If you don't hold a
-strong reference, the peripheral is deallocated and the connection fails silently.
-
-```swift
-// WRONG: No strong reference kept
-func centralManager(_ central: CBCentralManager,
-                    didDiscover peripheral: CBPeripheral, ...) {
-    central.connect(peripheral) // peripheral may be deallocated
-}
-
-// CORRECT: Retain the peripheral
-func centralManager(_ central: CBCentralManager,
-                    didDiscover peripheral: CBPeripheral, ...) {
-    self.discoveredPeripheral = peripheral // Strong reference
-    central.connect(peripheral)
-}
-```
-
-### DON'T: Scan for nil services in production
-
-```swift
-// WRONG: Discovers every BLE device in range -- drains battery
-centralManager.scanForPeripherals(withServices: nil)
-
-// CORRECT: Specify the service UUIDs you need
-centralManager.scanForPeripherals(withServices: [targetServiceUUID])
-```
-
-### DON'T: Assume connection order or timing
-
-```swift
-// WRONG: Assuming immediate connection
-centralManager.connect(peripheral)
-discoverServicesNow() // Peripheral not connected yet
-
-// CORRECT: Discover services in the didConnect callback
-func centralManager(_ central: CBCentralManager,
-                    didConnect peripheral: CBPeripheral) {
-    peripheral.delegate = self
-    peripheral.discoverServices([serviceUUID])
-}
-```
-
-### DON'T: Write without checking properties and flow control
-
-```swift
-// WRONG: May fail, report an error, or provide no confirmation
-peripheral.writeValue(data, for: characteristic, type: .withResponse)
-
-// CORRECT: Check properties, length, and .withoutResponse flow control
-if characteristic.properties.contains(.write),
-   data.count <= peripheral.maximumWriteValueLength(for: .withResponse) {
-    peripheral.writeValue(data, for: characteristic, type: .withResponse)
-} else if characteristic.properties.contains(.writeWithoutResponse),
-          peripheral.canSendWriteWithoutResponse,
-          data.count <= peripheral.maximumWriteValueLength(for: .withoutResponse) {
-    peripheral.writeValue(data, for: characteristic, type: .withoutResponse)
-}
-```
+| Mistake | Fix |
+|---|---|
+| Scan/connect before `.poweredOn` | Start BLE work from `centralManagerDidUpdateState`. |
+| Discovered peripheral is not retained | Hold a strong reference through connection and discovery. |
+| Production scan passes `nil` services | Filter by the service UUIDs the feature needs. |
+| Service discovery begins before `didConnect` | Advance only from delegate callbacks and handle failure/disconnect paths. |
+| Writes ignore characteristic properties or payload limits | Select the supported write type, respect `maximumWriteValueLength`, and gate `.withoutResponse` on `canSendWriteWithoutResponse`. |
 
 ## Review Checklist
 

--- a/skills/core-data/SKILL.md
+++ b/skills/core-data/SKILL.md
@@ -269,6 +269,8 @@ func markAllTripsAsNotFavorite() async throws {
 **Always merge changes** back into relevant contexts after batch operations.
 Batch delete does not enforce the Deny delete rule.
 
+For destructive or retryable batch work, use a proof loop: preflight the predicate and expected count, execute with an object-ID result type, merge IDs into live contexts, refetch, and assert the postcondition. On failure, restore a pristine fixture or prove the operation is idempotent before retrying; never blindly rerun a partially completed batch.
+
 ## Persistent History Tracking
 
 Track store-level changes across targets (app, extensions, widgets) and

--- a/skills/core-nfc/SKILL.md
+++ b/skills/core-nfc/SKILL.md
@@ -7,7 +7,7 @@ description: "Read and write NFC tags using CoreNFC. Use when scanning NDEF tags
 
 Read and write NFC tags on iPhone using the CoreNFC framework. Covers NDEF
 reader sessions, tag reader sessions, NDEF message construction, entitlements,
-and background tag reading. Targets Swift 6.3 / iOS 26+.
+and background tag reading.
 
 ## Contents
 

--- a/skills/coreml/SKILL.md
+++ b/skills/coreml/SKILL.md
@@ -7,7 +7,6 @@ description: "Integrate Core ML models in iOS apps for on-device machine learnin
 
 Load, configure, and run Core ML models in iOS apps. This skill covers the
 Swift side: model loading, prediction, MLTensor, profiling, and deployment.
-Target iOS 26+ with Swift 6.3, backward-compatible to iOS 14 unless noted.
 
 > **Scope boundary:** Python-side model conversion, optimization (quantization,
 > palettization, pruning), and framework selection live in the `apple-on-device-ai`
@@ -174,6 +173,11 @@ Use `predictions(fromBatch:)` when batching without explicit
 `MLPredictionOptions`. Use `predictions(from:options:)` only when passing both an
 `MLBatchProvider` and `MLPredictionOptions`; `predictions(from:)` by itself is
 not the no-options batch API.
+
+Validate a representative single input before batching. Then verify batch
+output count/order, feature types, domain invariants, and agreement with the
+single-input result. On failure, fix the deterministic input, shape, model, or
+configuration issue before rerunning fixtures and physical-device profiling.
 
 ### Stateful Prediction (iOS 18+)
 
@@ -380,49 +384,18 @@ Run outside the debugger for accurate results (Xcode: Product > Profile).
 
 ## Model Deployment
 
-### Bundle vs Downloaded Assets
-
-| Strategy | Pros | Cons |
-|---|---|---|
-| Bundle in app | Instant availability, works offline | Increases app download size |
-| Background Assets | Preferred for large or updateable model assets | Requires asset-pack setup |
-| On-demand resources | Smaller initial download for existing ODR apps | Legacy technology; prefer Background Assets for new work |
-| CloudKit / server | Maximum flexibility | Requires network, longer setup |
-
-### Size Considerations
-
-- For iOS/iPadOS 18+, App Store Connect lists a 4 GB thinned app bundle limit
-  and 8 GB thinned ODR asset-pack limit.
-- Prefer Background Assets for new large or updateable model assets; keep ODR
-  guidance for existing projects that already use it.
-- Pre-compile to `.mlmodelc` to skip on-device compilation
-- For downloaded `.mlmodel` or `.mlpackage` files, compile once with
-  `MLModel.compileModel(at:)`, move the resulting `.mlmodelc` out of Core ML's
-  temporary location, and cache it by model version.
-- Validate memory and performance on physical target devices, especially the
-  lowest-memory supported device. Check model load, first prediction, repeated
-  predictions, background/foreground transitions, and low-memory behavior.
-
-For Background Assets, make the asset pack locally available, resolve the model
-URL, then load the compiled model with `MLModel.load(contentsOf:configuration:)`.
-
-```swift
-// Existing On-Demand Resources project
-let request = NSBundleResourceRequest(tags: ["ml-model-v2"])
-try await request.beginAccessingResources()
-let modelURL = Bundle.main.url(forResource: "LargeModel", withExtension: "mlmodelc")!
-let model = try await MLModel.load(contentsOf: modelURL, configuration: config)
-// Call request.endAccessingResources() when done
-```
+Bundle small offline-critical models. Prefer Background Assets for new large or
+updateable assets; keep On-Demand Resources only for existing ODR projects.
+Compile downloaded source models once, persist the `.mlmodelc` by version, and
+test load, first/repeated prediction, lifecycle transitions, and memory on the
+lowest supported physical device. Load
+[deployment patterns](references/coreml-swift-integration.md) for implementation
+details.
 
 ## Memory Management
 
 - **Unload on background:** Release model references when the app enters background
   to free GPU/ANE memory. Reload on foreground return.
-- **Choose compute units by context:** use `.all` by default. Consider `.cpuOnly`
-  only when profiling or app policy shows accelerator contention, thermal state,
-  energy budget, deterministic testing, or a legitimate background execution
-  constraint makes CPU the right tradeoff.
 - **Share model instances:** Never create multiple `MLModel` instances from the same
   compiled model. Use an actor to provide shared access.
 - **Monitor memory pressure:** Large models (>100 MB) can trigger memory warnings.
@@ -437,21 +410,6 @@ lifecycle-aware loading and cache eviction.
 **DON'T:** Load models on the main thread.
 **DO:** Use `MLModel.load(contentsOf:configuration:)` async API or load on a background actor.
 **Why:** Large models can take seconds to load, freezing the UI.
-
-**DON'T:** Recompile `.mlpackage` to `.mlmodelc` on every app launch.
-**DO:** Compile once with `MLModel.compileModel(at:)` and cache the compiled URL persistently.
-**Why:** Compilation is expensive. Cache the `.mlmodelc` in Application Support.
-
-**DON'T:** Hardcode `.cpuOnly` unless you have a specific reason.
-**DO:** Use `.all` and let the system choose the optimal compute unit.
-**Why:** `.all` enables Neural Engine and GPU, which are faster and more energy-efficient.
-
-**DON'T:** Claim GPU or Neural Engine are categorically unavailable for all
-background-adjacent work.
-**DO:** Treat background execution as policy-, mode-, contention-, thermal-, and
-energy-dependent, and profile the actual workload on device.
-**Why:** Apps may be suspended, throttled, or limited by their background mode;
-`.cpuOnly` is a tradeoff, not a universal requirement.
 
 **DON'T:** Ignore `MLFeatureValue` type mismatches between input and model expectations.
 **DO:** Match types exactly -- use `MLFeatureValue(pixelBuffer:)` for images, not raw data.

--- a/skills/cryptokit/SKILL.md
+++ b/skills/cryptokit/SKILL.md
@@ -29,9 +29,7 @@ cryptographic primitive code targeting Swift 6.3+.
 
 ## Hashing
 
-CryptoKit provides SHA256, SHA384, and SHA512 hash functions on iOS 13+.
-SHA3_256, SHA3_384, and SHA3_512 are available on iOS 26+. All conform
-to the `HashFunction` protocol.
+Use SHA256/SHA384/SHA512 on iOS 13+; SHA3_256/SHA3_384/SHA3_512 require iOS 26+. All conform to `HashFunction`.
 
 ### One-shot hashing
 
@@ -42,8 +40,6 @@ let data = Data("Hello, world!".utf8)
 let digest = SHA256.hash(data: data)
 let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
 ```
-
-SHA384 and SHA512 work identically -- substitute the type name.
 
 ### SHA-3 availability
 
@@ -82,7 +78,7 @@ if expected == actual {
 
 ## HMAC
 
-HMAC provides message authentication using a symmetric key and a hash function.
+Use HMAC when a protocol requires keyed message authentication; verify with `isValidAuthenticationCode` rather than comparing serialized values yourself.
 
 ### Computing an authentication code
 
@@ -100,8 +96,6 @@ let isValid = HMAC<SHA256>.isValidAuthenticationCode(
     mac, authenticating: data, using: key
 )
 ```
-
-This uses constant-time comparison internally.
 
 ### Incremental HMAC
 

--- a/skills/cryptotokenkit/SKILL.md
+++ b/skills/cryptotokenkit/SKILL.md
@@ -360,32 +360,10 @@ revocation, `3` = + hard revocation.
 ## Token Watching
 
 `TKTokenWatcher` monitors token insertion and removal. Available on iOS 10+
-and macOS 10.12+.
-
-```swift
-import CryptoTokenKit
-
-final class TokenMonitor {
-    private let watcher = TKTokenWatcher()
-
-    func startMonitoring() {
-        for tokenID in watcher.tokenIDs {
-            print("Token present: \(tokenID)")
-            if let info = watcher.tokenInfo(forTokenID: tokenID) {
-                print("  Driver: \(info.driverName ?? "unknown")")
-                print("  Slot: \(info.slotName ?? "unknown")")
-            }
-        }
-
-        watcher.setInsertionHandler { [weak self] tokenID in
-            print("Token inserted: \(tokenID)")
-            self?.watcher.addRemovalHandler({ removedTokenID in
-                print("Token removed: \(removedTokenID)")
-            }, forTokenID: tokenID)
-        }
-    }
-}
-```
+and macOS 10.12+. Enumerate `tokenIDs`, install an insertion handler, then add a
+removal handler for each observed token. Keep the watcher alive for as long as
+monitoring is required. For slot-level reader state, use
+[Smart Card Slot Monitoring](references/cryptotokenkit-patterns.md#smart-card-slot-monitoring).
 
 ## Error Handling
 

--- a/skills/device-integrity/SKILL.md
+++ b/skills/device-integrity/SKILL.md
@@ -185,10 +185,6 @@ actor AppAttestManager {
 }
 ```
 
-**Important:** Generate the key once per user account on a device, persist that
-account/device `keyId`, and keep the key count low. Generating unnecessary keys
-pollutes App Attest risk metrics.
-
 ## App Attest Attestation Flow
 
 Attestation proves that the key was generated on a genuine Apple device running

--- a/skills/energykit/SKILL.md
+++ b/skills/energykit/SKILL.md
@@ -8,7 +8,7 @@ description: "Query grid electricity forecasts and submit load events using Ener
 Provide grid electricity forecasts to help users choose when to use electricity.
 EnergyKit identifies times when grid electricity is relatively cleaner and,
 when cost information is available, less expensive. Apps use that guidance to
-shift or reduce managed device load. Targets Swift 6.3 / iOS 26+.
+shift or reduce managed device load.
 
 > **Beta-sensitive.** EnergyKit is new in iOS 26 and may change before GM.
 > Re-check current Apple documentation before relying on specific API details.
@@ -364,113 +364,22 @@ year. See [references/energykit-patterns.md](references/energykit-patterns.md) f
 
 ## Common Mistakes
 
-### DON'T: Forget the EnergyKit entitlement
-
-Without the entitlement, EnergyKit APIs can fail with permission errors such as
-`EnergyKitError.permissionDenied`. Treat the EnergyKit capability as setup, not
-as an implementation detail to discover after writing queries.
-
-### DON'T: Ignore unsupported regions
-
-EnergyKit is not available in all regions. Handle the `.unsupportedRegion`
-and `.guidanceUnavailable` errors.
-
-```swift
-// WRONG: Assume guidance is always available
-for try await guidance in service.guidance(using: query, at: venueID) {
-    updateUI(guidance)
-}
-
-// CORRECT: Handle region-specific errors
-do {
-    for try await guidance in service.guidance(using: query, at: venueID) {
-        updateUI(guidance)
-    }
-} catch let error as EnergyKitError {
-    switch error {
-    case .unsupportedRegion:
-        showUnsupportedRegionMessage()
-    case .guidanceUnavailable:
-        showGuidanceUnavailableMessage()
-    case .venueUnavailable:
-        showNoVenueMessage()
-    case .permissionDenied:
-        showPermissionDeniedMessage()
-    case .serviceUnavailable:
-        retryLater()
-    case .rateLimitExceeded:
-        backOff()
-    default:
-        break
-    }
-}
-```
-
-### DON'T: Discard the guidance token
-
-The `guidanceToken` links load events to the guidance that was in effect. Store
-the token returned from EnergyKit on the device that fetched it and pass that
-real token to load event submissions.
-
-```swift
-// WRONG: Ignore the guidance token
-for try await guidance in guidanceStream {
-    startCharging(followingGuidanceToken: UUID())  // fabricated token
-}
-
-// CORRECT: Store the token for load events
-for try await guidance in guidanceStream {
-    let token = guidance.guidanceToken
-    startCharging(followingGuidanceToken: token)
-}
-```
-
-### DON'T: Submit load events without a session lifecycle
-
-Always submit `.begin`, then `.active` updates, then `.end` events.
-
-```swift
-// WRONG: Only submit one event
-let event = ElectricVehicleLoadEvent(/* state: .active */)
-try await venue.submitEvents([event])
-
-// CORRECT: Full session lifecycle
-try await venue.submitEvents([beginEvent])
-// ... periodic active events ...
-try await venue.submitEvents([activeEvent])
-// ... when done ...
-try await venue.submitEvents([endEvent])
-```
-
-### DON'T: Query guidance without a venue
-
-EnergyKit requires a venue ID. List venues first and select the appropriate one.
-
-```swift
-// WRONG: Use a hardcoded UUID
-let fakeID = UUID()
-service.guidance(using: query, at: fakeID)  // Will fail
-
-// CORRECT: Discover venues first
-let venues = try await EnergyVenue.venues()
-guard let venue = venues.first else {
-    showNoVenueSetup()
-    return
-}
-let guidanceStream = service.guidance(using: query, at: venue.id)
-```
+| Mistake | Fix |
+|---|---|
+| Querying before capability setup | Verify the EnergyKit entitlement and handle `.permissionDenied`. |
+| Assuming every region has guidance | Handle unsupported-region, unavailable-venue/guidance, service, and rate-limit states. |
+| Fabricating or discarding the guidance token | Persist the real token on the requesting device and submit that token with its load events. |
+| Sending isolated load samples | Preserve `.begin → .active → .end` and Apple's event cadence. |
+| Using a hardcoded venue ID | Discover venues with `EnergyVenue.venues()` and select the intended venue. |
 
 ## Review Checklist
 
 - [ ] `com.apple.developer.energykit` entitlement added to the project
 - [ ] `EnergyKitError.unsupportedRegion` handled with user-facing message
 - [ ] `EnergyKitError.permissionDenied` handled gracefully
-- [ ] Guidance token stored and passed to load event submissions
-- [ ] No placeholder or fabricated guidance tokens are used in load events
-- [ ] The same EnergyKit-capable device/app that requested guidance submits the corresponding load events
+- [ ] Real guidance token stored and submitted by the same EnergyKit-capable device/app
 - [ ] Venues discovered via `EnergyVenue.venues()` before querying guidance
-- [ ] Load event sessions follow `.begin` -> `.active` -> `.end` lifecycle
-- [ ] EV/HVAC event cadence follows Apple guidance and events are batched when practical
+- [ ] Load event sessions follow `.begin` -> `.active` -> `.end`, with Apple cadence and practical batching
 - [ ] `ElectricityGuidance.Value.rating` interpreted correctly (lower is better)
 - [ ] `SuggestedAction` matches the device type (`.shift` for EV, `.reduce` for HVAC)
 - [ ] Insight queries use appropriate minimum ranges for their granularity

--- a/skills/financekit/SKILL.md
+++ b/skills/financekit/SKILL.md
@@ -414,50 +414,11 @@ do {
 }
 ```
 
-### 4. Requesting full snapshots instead of resumable queries
+### 4. Replacing resumable history with snapshots
 
-DON'T -- fetch everything on every launch:
-```swift
-let allTransactions = try await store.transactions(query: TransactionQuery(
-    sortDescriptors: [SortDescriptor(\Transaction.transactionDate)],
-    predicate: nil, limit: nil, offset: nil
-))
-```
+Use the canonical transaction-history loop above and persist each `newToken` only after local deletes and upserts commit. Keep separate tokens per stream/account; on invalid-token errors, resync only the affected scope.
 
-DO -- use history tokens for incremental sync:
-```swift
-let history = store.transactionHistory(
-    forAccountID: accountID,
-    since: loadSavedToken(),
-    isMonitoring: false
-)
-for try await changes in history {
-    removeLocalRecords(withIDs: changes.deleted)
-    upsert(changes.inserted + changes.updated)
-    saveToken(changes.newToken)
-}
-```
-
-### 5. Not persisting history tokens
-
-DON'T -- discard the token:
-```swift
-for try await changes in history {
-    processChanges(changes)
-    // Token lost -- next launch reprocesses everything
-}
-```
-
-DO -- save every token:
-```swift
-for try await changes in history {
-    removeLocalRecords(withIDs: changes.deleted)
-    upsert(changes.inserted + changes.updated)
-    saveToken(changes.newToken)
-}
-```
-
-### 6. Misinterpreting credit/debit on liability accounts
+### 5. Misinterpreting credit/debit on liability accounts
 
 Both asset and liability accounts use `.debit` for outgoing money. But `.credit` means different things: on an asset account it means money received; on a liability account it means a payment or refund that increases available credit. See [references/financekit-patterns.md](references/financekit-patterns.md) for a full interpretation table.
 

--- a/skills/homekit/SKILL.md
+++ b/skills/homekit/SKILL.md
@@ -6,8 +6,7 @@ description: "Control smart-home accessories and commission Matter devices using
 # HomeKit
 
 Control home automation accessories and commission Matter devices. HomeKit manages
-the home/room/accessory model, action sets, and triggers. MatterSupport handles
-device commissioning into your ecosystem. Targets Swift 6.3 / iOS 26+.
+the home/room/accessory model, action sets, and triggers. MatterSupport handles device commissioning into your ecosystem.
 
 ## Contents
 
@@ -45,18 +44,13 @@ For Matter commissioning into your own ecosystem:
 3. Add `com.apple.developer.matter.allow-setup-payload` only if the caller
    supplies a Matter setup payload programmatically
 
-### Availability Check
+### Framework Boundary
 
-```swift
-import HomeKit
-
-let homeManager = HMHomeManager()
-
-// HomeKit is available on iPhone, iPad, Apple TV, Apple Watch,
-// Mac Catalyst, and Vision Pro.
-// Authorization is handled through the delegate:
-homeManager.delegate = self
-```
+| Need | Framework |
+|---|---|
+| Homes, rooms, accessories, characteristics, actions, triggers | HomeKit |
+| Commission Matter into the app ecosystem | MatterSupport |
+| Privacy-preserving BLE/Wi-Fi accessory selection | AccessorySetupKit, then CoreBluetooth/NetworkExtension |
 
 ## HomeKit Data Model
 
@@ -400,68 +394,13 @@ final class MatterHandler: MatterAddDeviceExtensionRequestHandler {
 
 ## Common Mistakes
 
-### DON'T: Access homes before the delegate fires
-
-```swift
-// WRONG -- homes array is empty until delegate is called
-let manager = HMHomeManager()
-let homes = manager.homes  // Always empty here
-
-// CORRECT -- wait for delegate
-func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
-    let homes = manager.homes  // Now populated
-}
-```
-
-### DON'T: Confuse HomeKit setup with Matter commissioning
-
-```swift
-// WRONG -- using HomeKit accessory setup for a Matter ecosystem app
-home.addAndSetupAccessories { error in }
-
-// CORRECT -- use MatterAddDeviceRequest for Matter ecosystem commissioning
-let request = MatterAddDeviceRequest(
-    topology: topology,
-    setupPayload: nil,
-    showing: .allDevices
-)
-try await request.perform()
-```
-
-### DON'T: Forget required configuration
-
-Matter ecosystem commissioning needs the MatterSupport extension, principal
-handler class, and Matter Bonjour services. Add the setup-payload entitlement
-only when your app provides setup codes directly.
-
-### DON'T: Create multiple HMHomeManager instances
-
-```swift
-// WRONG -- each instance loads the full database independently
-class ScreenA { let manager = HMHomeManager() }
-class ScreenB { let manager = HMHomeManager() }
-
-// CORRECT -- single shared instance
-@Observable
-final class HomeStore {
-    static let shared = HomeStore()
-    let homeManager = HMHomeManager()
-}
-```
-
-### DON'T: Write characteristics without checking metadata
-
-```swift
-// WRONG -- writing a value outside the valid range
-characteristic.writeValue(500) { _ in }
-
-// CORRECT -- check metadata first
-if let metadata = characteristic.metadata,
-   let maxValue = metadata.maximumValue?.intValue {
-    let safeValue = min(brightness, maxValue)
-    characteristic.writeValue(safeValue) { _ in }
-}
-```
+| Mistake | Fix |
+|---|---|
+| Reading homes before the delegate update | Create one manager, set its delegate, and wait for `homeManagerDidUpdateHomes`. |
+| HomeKit setup is used for Matter ecosystem commissioning | Use `MatterAddDeviceRequest` plus the configured MatterSupport extension. |
+| Matter configuration is incomplete | Verify principal handler, Bonjour services, and the setup-payload entitlement only when applicable. |
+| Multiple `HMHomeManager` instances load the database | Share one retained manager/store. |
+| Characteristic write ignores metadata | Check permissions, format, min/max/step, and allowed values before writing. |
 
 ## Review Checklist
 

--- a/skills/ios-accessibility/SKILL.md
+++ b/skills/ios-accessibility/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ios-accessibility
-description: "Implements, reviews, or improves accessibility in iOS/macOS apps with SwiftUI, UIKit, and AppKit. Use when adding VoiceOver, Voice Control, Switch Control, or Full Keyboard Access support; when working with accessibility labels, hints, values, traits, accessibilityInputLabels, NSAccessibility, grouping, reading order, accessibility focus restoration with @AccessibilityFocusState, Dynamic Type, @ScaledMetric, custom rotors, accessibility actions, XCTest accessibility checks, App Store Accessibility Nutrition Labels, App Store Connect accessibility answers, a11y compliance audits, or system accessibility preferences."
+description: "Builds and audits SwiftUI, UIKit, and AppKit accessibility for VoiceOver, Voice Control, Switch Control, Full Keyboard Access, Dynamic Type, focus restoration, labels/traits/actions, traversal, custom rotors, NSAccessibility, XCTest checks, adaptive system preferences, and App Store accessibility declarations."
 ---
 
 # iOS/macOS Accessibility - SwiftUI, UIKit, and AppKit
 
-Every user-facing view must be usable with VoiceOver, Switch Control, Voice Control, Full Keyboard Access, and other assistive technologies. This skill covers SwiftUI, UIKit, and AppKit patterns required to build accessible iOS, iPadOS, and macOS apps.
+Build SwiftUI, UIKit, and AppKit interfaces that remain operable with VoiceOver, Switch Control, Voice Control, Full Keyboard Access, and adaptive accessibility settings.
 
 ## Contents
 
@@ -62,7 +62,7 @@ Focus management is where most apps fail. When a sheet, alert, or popover is dis
 
 This section is about accessibility focus for assistive technologies. For keyboard focus, directional focus, `focusSection()`, scene-focused values, and `UIFocusGuide`, use the `focus-engine` skill.
 
-When triaging broad focus bugs, still call out accessibility traversal separately: accessibility element order and grouping in the view hierarchy directly affect VoiceOver swipe order, Switch Control scan order, Voice Control overlay targeting, and Full Keyboard Access reachability review. Route keyboard-focus implementation to `focus-engine`, but keep this traversal impact in `ios-accessibility`.
+Audit element order and grouping in [Traversal Order](#traversal-order); route keyboard-focus mechanics to `focus-engine`.
 
 ### `@AccessibilityFocusState` (iOS 15+)
 
@@ -242,7 +242,7 @@ See [references/a11y-patterns.md](references/a11y-patterns.md) for custom action
 
 Full Keyboard Access (iOS/iPadOS 13.4+) lets users navigate and operate an app with a hardware keyboard.
 
-This skill covers the accessibility review surface: whether all controls are reachable, clearly labeled, visibly focused, and operable without touch. If the bug is Tab traversal, skipped custom cards, `.focusable()`, `@FocusState`, `focusSection()`, directional movement, scene-focused values, tvOS focus behavior, or `UIFocusGuide`, route implementation to the `focus-engine` skill first. Keep only the accessibility finding here.
+Audit whether every control is reachable, labeled, visibly focused, and operable without touch. Route Tab/directional focus, `.focusable()`, `@FocusState`, `focusSection()`, scene-focused values, tvOS focus, and `UIFocusGuide` implementation to `focus-engine`.
 
 - Every interactive element can be reached and activated with the keyboard.
 - Traversal order is logical and does not trap focus.
@@ -254,7 +254,7 @@ See [references/a11y-patterns.md](references/a11y-patterns.md) for Full Keyboard
 
 ## Traversal Order
 
-Explicitly assess how accessibility element order and grouping affect traversal outcomes: VoiceOver swipe order, Switch Control scan order, Voice Control overlay targeting, and Full Keyboard Access reachability review can all break when grouping/order differs from visual or task order. Missing labels, duplicate labels, excessive row children, hidden custom controls, or grouping that does not match the visual/task order can make traversal confusing across all of them. Keep implementation mechanics for keyboard or directional routing in `focus-engine`; keep the accessibility impact and ordering audit here.
+Element order and grouping must follow visual and task order across VoiceOver swipe order, Switch Control scanning, Voice Control overlays, and Full Keyboard Access review. Check missing or duplicate labels, excessive row children, hidden custom controls, focus traps, and groups whose order diverges from the task. Keep keyboard or directional routing mechanics in `focus-engine`.
 
 ## Assistive Access (iOS 18+)
 
@@ -281,70 +281,15 @@ Key guidelines:
 
 ## UIKit Accessibility Patterns
 
-When working with UIKit views:
-
-- Set `isAccessibilityElement = true` on meaningful custom views.
-- Set `accessibilityLabel` on all interactive elements without visible text.
-- Use `.insert()` and `.remove()` for trait modification (not direct assignment).
-- Set `accessibilityViewIsModal = true` on custom overlay views to trap focus.
-- Post `.announcement` for transient status messages.
-- Post `.layoutChanged` with a target view for partial screen updates.
-- Post `.screenChanged` for full screen transitions.
-
-```swift
-// UIKit trait modification
-customButton.accessibilityTraits.insert(.button)
-customButton.accessibilityTraits.remove(.staticText)
-
-// Modal overlay
-overlayView.accessibilityViewIsModal = true
-```
+For custom UIKit views, expose meaningful elements, labels, values, traits, and actions; mutate traits with `insert`/`remove`; make custom overlays modal; and use the appropriate announcement, layout-changed, or screen-changed notification. Load [references/a11y-patterns.md](references/a11y-patterns.md) for complete UIKit examples.
 
 ## AppKit Accessibility Patterns
 
-AppKit accessibility uses `NSAccessibilityProtocol` and related role-specific protocols to describe accessible elements. Standard AppKit controls already provide much of this behavior; customize labels, values, roles, and actions only when the defaults are insufficient.
-
-- Prefer standard AppKit controls first — they already expose accessibility metadata and notifications.
-- For custom `NSView` subclasses, adopt the appropriate role-specific accessibility behavior and return the correct role, label, value, and actions.
-- Use `NSAccessibilityElement` for accessible items that are not backed by their own `NSView`.
-- Post `NSAccessibility` notifications when state changes need to be announced to assistive apps.
-
-```swift
-final class FavoriteToggleView: NSView {
-    var isFavorite = false {
-        didSet {
-            NSAccessibility.post(element: self, notification: .valueChanged)
-        }
-    }
-
-    override func isAccessibilityElement() -> Bool { true }
-    override func accessibilityRole() -> NSAccessibility.Role? { .button }
-    override func accessibilityLabel() -> String? { "Favorite" }
-    override func accessibilityValue() -> Any? { isFavorite ? "On" : "Off" }
-
-    override func accessibilityPerformPress() -> Bool {
-        isFavorite.toggle()
-        return true
-    }
-}
-```
-
-See [references/a11y-patterns.md](references/a11y-patterns.md) for AppKit examples including `NSAccessibilityElement` and announcement notifications.
+Prefer standard AppKit controls. For custom `NSView` or virtual elements, expose the correct `NSAccessibility` role, label, value, actions, and state-change notifications. Load [references/a11y-patterns.md](references/a11y-patterns.md) for `NSAccessibilityElement` and custom-control examples.
 
 ## Accessibility Custom Content
 
-See [references/a11y-patterns.md](references/a11y-patterns.md) for UIKit and AppKit accessibility patterns and custom content examples.
-
-```swift
-ProductRow(product: product)
-    .accessibilityCustomContent("Price", product.formattedPrice)
-    .accessibilityCustomContent("Rating", "\(product.rating) out of 5")
-    .accessibilityCustomContent(
-        "Availability",
-        product.inStock ? "In stock" : "Out of stock",
-        importance: .high  // .high reads automatically with the element
-    )
-```
+Use `.accessibilityCustomContent` for useful secondary facts without adding swipe stops; reserve high importance for content that should read automatically. See [references/a11y-patterns.md](references/a11y-patterns.md) for SwiftUI, UIKit, and AppKit examples.
 
 ## App Store Accessibility Nutrition Labels
 
@@ -356,7 +301,7 @@ Before recommending a claim, require evidence that users can complete all common
 
 ### Manual Testing
 
-- **Accessibility Inspector** (Xcode > Open Developer Tool): Audit views for missing labels, traits, and contrast issues. Run audits against the Simulator or connected device.
+- **Accessibility Inspector**: Audit labels, traits, and contrast against Simulator and devices.
 - **VoiceOver testing**: Enable in Settings > Accessibility > VoiceOver. Navigate every screen with swipe gestures.
 - **Voice Control testing**: Enable in Settings > Accessibility > Voice Control. Say both "Show Names" and "Show Numbers"; names verify speakable labels, while numbers verify every visible interactive target is reachable even when names are duplicated, missing, or awkward.
 - **Full Keyboard Access testing**: Enable in Settings > Accessibility > Keyboards > Full Keyboard Access. Tab through every screen and verify all interactive elements receive focus.
@@ -365,60 +310,19 @@ Before recommending a claim, require evidence that users can complete all common
 
 ### Automated Testing with XCTest
 
-Use `XCUIElement` accessibility attributes to write UI tests that verify accessibility properties:
-
-```swift
-func testProductRowAccessibility() throws {
-    let app = XCUIApplication()
-    app.launch()
-
-    let productCell = app.cells["product-organic-apples"]
-    XCTAssertTrue(productCell.exists)
-    XCTAssertTrue(productCell.isEnabled)
-
-    // Verify the label is set and meaningful
-    XCTAssertFalse(productCell.label.isEmpty)
-
-    // Verify a specific element has the expected label
-    let favoriteButton = productCell.buttons["Favorite"]
-    XCTAssertTrue(favoriteButton.exists)
-    XCTAssertTrue(favoriteButton.isEnabled)
-}
-```
-
-Key `XCUIElementAttributes` properties for accessibility verification: `label`, `identifier`, `value`, `isEnabled`, `hasFocus`, `isSelected`, `placeholderValue`, `title`.
-
-Test dismissal focus restoration:
-
-```swift
-func testSheetDismissReturnsFocus() throws {
-    let app = XCUIApplication()
-    app.launch()
-
-    let triggerButton = app.buttons["Open Settings"]
-    triggerButton.tap()
-
-    // Dismiss the sheet
-    let doneButton = app.buttons["Done"]
-    doneButton.tap()
-
-    // Verify focus returns to trigger (in accessibility-focused testing)
-    XCTAssertTrue(triggerButton.hasFocus)
-}
-```
+Use stable accessibility identifiers to locate `XCUIElement` values, then assert existence, enabled/selected state, meaningful labels/values, and `hasFocus` where the test environment exposes focus. Cover dismissal focus restoration, every modal exit path, and gesture alternatives. UI automation complements—not replaces—VoiceOver, Voice Control, Switch Control, keyboard, Dynamic Type, contrast, Reduce Motion, and Reduce Transparency testing. Load [references/a11y-patterns.md](references/a11y-patterns.md) for XCTest examples.
 
 ## Common Mistakes
 
-1. **Direct trait assignment**: UIKit trait mutation or incorrect SwiftUI trait APIs can overwrite existing behavior. In SwiftUI, use `.accessibilityAddTraits(.isButton)`.
-2. **Missing focus restoration**: Dismissing sheets without returning VoiceOver focus to the trigger element.
-3. **Ungrouped list rows**: Multiple text elements per row create excessive swipe stops. Use `.accessibilityElement(children: .combine)`.
-4. **Redundant trait in labels**: `.accessibilityLabel("Settings button")` reads as "Settings button, button." Omit the type.
-5. **Missing labels on icon-only buttons**: Every `Image`-only button MUST have `.accessibilityLabel`.
-6. **Ignoring Reduce Motion**: Always check `accessibilityReduceMotion` before movement animations.
-7. **Fixed font sizes**: `.font(.system(size: 16))` ignores Dynamic Type. Use `.font(.body)` or similar text styles.
-8. **Small tap targets**: Icons without `frame(minWidth: 44, minHeight: 44)` and `.contentShape()`.
-9. **Color as sole indicator**: Red/green for error/success without text or icon alternatives.
-10. **Missing `.isModal` on overlays**: Custom modals without `.accessibilityAddTraits(.isModal)` let VoiceOver escape.
+| Mistake | Fix |
+|---|---|
+| Trait assignment overwrites behavior | Insert/remove UIKit traits or use SwiftUI accessibility trait modifiers. |
+| Dismissal loses focus | Return accessibility focus to the trigger. |
+| Rows create excessive swipe stops | Group related children deliberately. |
+| Labels repeat control type or omit icon meaning | Use a concise, speakable action/name; traits announce type. |
+| Motion, text size, contrast, or transparency is fixed | Respond to the matching accessibility preference and adaptive text styles. |
+| Targets are small or color-only | Provide a 44×44 target plus text, shape, or icon semantics. |
+| Custom overlay is not modal | Expose modal semantics, escape action, and restoration. |
 
 ## Review Checklist
 

--- a/skills/ios-localization/SKILL.md
+++ b/skills/ios-localization/SKILL.md
@@ -5,12 +5,12 @@ description: "Implement, review, or improve localization and internationalizatio
 
 # iOS Localization & Internationalization
 
-Localize iOS 26+ apps using String Catalogs, modern string types, FormatStyle, and RTL-aware layout. Localization mistakes cause App Store rejections in non-English markets, mistranslated UI, and broken layouts. Ship with correct localization from the start.
+Localize Apple-platform apps with String Catalogs, modern string types,
+locale-aware formatting, and right-to-left layout.
 
 ## Contents
 
-- [String Catalogs (.xcstrings)](#string-catalogs-xcstrings)
-- [String Catalogs (Xcode 15+) and Generated Symbols (Xcode 26+)](#string-catalogs-xcode-15-and-generated-symbols-xcode-26)
+- [String Catalogs and Generated Symbols](#string-catalogs-and-generated-symbols)
 - [String Types -- Decision Guide](#string-types-decision-guide)
 - [String Interpolation in Localized Strings](#string-interpolation-in-localized-strings)
 - [Pluralization](#pluralization)
@@ -20,14 +20,9 @@ Localize iOS 26+ apps using String Catalogs, modern string types, FormatStyle, a
 - [Localization Review Checklist](#review-checklist)
 - [References](#references)
 
-## String Catalogs (.xcstrings)
+## String Catalogs and Generated Symbols
 
 String Catalogs are the recommended Xcode 15+ workflow for new localization work. They keep localizable strings, pluralization rules, and device variations together in an Xcode-managed JSON file with a visual editor. Legacy `.strings` and `.stringsdict` files can coexist during migration, but new Swift and SwiftUI code should default to String Catalogs.
-
-**Why String Catalogs exist:**
-- `.strings` files required manual key management and fell out of sync
-- `.stringsdict` required complex XML for plurals
-- String Catalogs auto-extract strings from code, track translation state, and support plurals natively
 
 **How automatic extraction works:**
 
@@ -52,9 +47,8 @@ Xcode adds discovered keys to the String Catalog automatically. Mark translation
 
 For detailed String Catalog workflows, migration, and testing strategies, see [references/string-catalogs.md](references/string-catalogs.md).
 
-## String Catalogs (Xcode 15+) and Generated Symbols (Xcode 26+)
-
-For generated-symbol or migration answers, start by stating: "String Catalogs are the recommended Xcode 15+ localization workflow. Xcode 26 generated symbols are a separate typed-access layer on top of String Catalogs." Then explain generated symbols, plurals, or migration details. Do not describe catalogs themselves as requiring Xcode 26 or iOS 17.
+Generated symbols are an Xcode 26 typed-access layer on top of String Catalogs;
+they do not change the catalog's Xcode 15 availability.
 
 **Enable:** Build Settings > Localization > Generate String Catalog Symbols → `Yes` (on by default in new Xcode 26 projects). Requires catalog format version `1.1`.
 
@@ -224,14 +218,9 @@ String Catalogs support device-specific text (iPhone vs iPad vs Mac):
 
 ### Grammar Agreement (iOS 15+)
 
-Use `^[...]` inflection syntax for automatic grammatical agreement:
-
-```swift
-// Automatically adjusts for gender/number in supported languages
-Text("^[\(count) \("photo")](inflect: true) added")
-// English: "1 photo added" / "3 photos added"
-// Spanish: "1 foto agregada" / "3 fotos agregadas"
-```
+Use Foundation's automatic grammar agreement markup when nearby words must
+inflect for a value's number or gender. Preserve the complete inflecting phrase
+for translators; see [Automatic Grammar Agreement](https://sosumi.ai/documentation/foundation/automatic-grammar-agreement).
 
 ## FormatStyle -- Locale-Aware Formatting
 

--- a/skills/ios-localization/references/string-catalogs.md
+++ b/skills/ios-localization/references/string-catalogs.md
@@ -396,7 +396,8 @@ The `manual` state is significant: manual keys have the **Generate Swift Symbol*
 
 ## Generated Localizable Symbols (Xcode 26+)
 
-For generated-symbol or migration answers, start by stating: "String Catalogs are the recommended Xcode 15+ localization workflow. Xcode 26 generated symbols are a separate typed-access layer on top of String Catalogs." Then explain generated symbols, plurals, or migration details. Do not describe catalogs themselves as requiring Xcode 26 or iOS 17.
+Generated symbols are an Xcode 26 typed-access layer on top of String Catalogs;
+do not describe catalogs themselves as requiring Xcode 26 or iOS 17.
 
 ### Enabling symbol generation
 

--- a/skills/ios-memgraph-analysis/SKILL.md
+++ b/skills/ios-memgraph-analysis/SKILL.md
@@ -183,14 +183,13 @@ not proof.
 
 ## Common Mistakes
 
-- Calling every retained object a leak.
 - Declaring the app leak-free because `leaks` returned zero once.
 - Selecting the first PID or Simulator from an ambiguous list.
 - Enabling Malloc Stack Logging in only one side of a comparison.
 - Treating a parser's best-effort type column as an API guarantee.
 - Pasting enormous reference trees into a report without finding an app edge.
 - Fixing every closure with `[weak self]` without reasoning about lifetime.
-- Claiming success from graph size, RSS, or total-count changes alone.
+- Claiming success from graph size, RSS, or total-count changes without proving the target lifetime and ownership path.
 
 ## Review Checklist
 

--- a/skills/ios-networking/SKILL.md
+++ b/skills/ios-networking/SKILL.md
@@ -5,10 +5,9 @@ description: "Build, review, or improve networking code in iOS/macOS apps using 
 
 # iOS Networking
 
-Modern networking patterns for iOS 26+ using URLSession with async/await and
-structured concurrency. All examples target Swift 6.3. No third-party
-dependencies required -- URLSession covers the vast majority of networking
-needs.
+Use URLSession with async/await and structured concurrency for ordinary HTTP,
+REST, uploads, downloads, and streaming. Use Network.framework for lower-level
+protocols and delegate/task APIs for durable background transfers.
 
 ## Contents
 
@@ -29,6 +28,12 @@ URLSession gained native async/await overloads in iOS 15. Prefer these for
 foreground data, upload, download, and streaming work. Background URLSession
 transfers are the main exception: they still use task/delegate APIs so the
 system can deliver events after suspension or relaunch.
+
+Validate networking policy locally with `URLProtocol` fixtures for valid 2xx,
+malformed 2xx, one-time 401 refresh, bounded 429/5xx retry, timeout/offline,
+cancellation, and nonretryable 4xx. Inspect headers, status, and error
+classification; fix the policy and rerun. Retry only safe/idempotent or
+explicitly replayable requests, and never loop token refresh.
 
 ### Data Requests
 
@@ -366,52 +371,20 @@ async throwing APIs; see [references/network-framework.md#quic-multiplexed-strea
 
 ## Configuring URLSession
 
-Create a configured session for production code. `URLSession.shared` is
-acceptable only for simple, one-off requests.
-
-```swift
-let configuration = URLSessionConfiguration.default
-configuration.timeoutIntervalForRequest = 30
-configuration.timeoutIntervalForResource = 300
-configuration.waitsForConnectivity = true
-configuration.requestCachePolicy = .returnCacheDataElseLoad
-configuration.httpAdditionalHeaders = [
-    "Accept": "application/json",
-    "Accept-Language": Locale.preferredLanguages.first ?? "en"
-]
-
-let session = URLSession(configuration: configuration)
-```
-
-`waitsForConnectivity = true` is valuable -- it makes the session wait for
-a network path instead of failing immediately when offline. Combine with
-`urlSession(_:taskIsWaitingForConnectivity:)` delegate callback for UI
-feedback.
+Inject a configured session when production code needs timeouts, caching,
+connectivity waiting, data-cost policy, authentication challenges, redirects,
+metrics, or background delegates. Use `URLSession.shared` only for simple
+one-off work. See [URLSession patterns](references/urlsession-patterns.md) for
+the full configuration and test setup.
 
 ## App Transport Security (ATS)
 
-ATS enforces HTTPS for all connections by default. Do not disable it.
-ATS is URL Loading System policy, so it covers `URLSession` rather than making
-lower-level `Network.framework` connections secure automatically. When using
-Network.framework, configure secure TLS parameters and trust handling correctly
-for that protocol stack.
-
-Use domain-specific ATS exceptions only as a last resort.
-
-**Rules:**
-- Never set `NSAllowsArbitraryLoads` to `true` in production unless there is no narrower option.
-- ATS exceptions require justification and may trigger additional App Store review.
-- Use exception domains only for third-party servers you cannot upgrade to HTTPS.
-- `NSAllowsLocalNetworking` is acceptable for local device communication (Bonjour, IoT).
-- Prefer ATS `NSPinnedDomains` for declarative pinning when possible. Raw bytes
-  from `SecKeyCopyExternalRepresentation` are not sufficient for SPKI pinning;
-  correct SPKI pinning hashes Subject Public Key Info and belongs in `swift-security`.
+ATS makes HTTPS the URL Loading System default. Do not enable blanket arbitrary
+loads; use the narrowest justified domain/local-network exception. Configure TLS
+explicitly for Network.framework. Keep deep trust and SPKI pinning design in
+`swift-security`.
 
 ## Common Mistakes
-
-**DON'T:** Use `URLSession.shared` with custom configuration needs.
-**DO:** Create a configured `URLSession` with appropriate timeouts, caching,
-and delegate for production code.
 
 **DON'T:** Force-unwrap `URL(string:)` with dynamic input.
 **DO:** Use `URL(string:)` with proper error handling. Force-unwrap is
@@ -436,18 +409,8 @@ libraries for genuinely missing features (e.g., image caching).
 **DO:** Use `URLProtocol` subclass for transport-level mocking, or use
 protocol-based clients that accept a test double.
 
-**DON'T:** Use `data(for:)` for large file downloads.
-**DO:** Use `download(for:)` which streams to disk and avoids memory spikes.
-
 **DON'T:** Fire network requests from `body` or view initializers.
 **DO:** Use `.task` or `.task(id:)` to trigger network calls.
-
-**DON'T:** Hardcode authentication tokens in requests.
-**DO:** Inject tokens via middleware so they are centralized and refreshable.
-
-**DON'T:** Ignore HTTP status codes and decode blindly.
-**DO:** Validate status codes before decoding. A 200 with invalid JSON and
-a 500 with an error body require different handling.
 
 ## Review Checklist
 

--- a/skills/ios-simulator/SKILL.md
+++ b/skills/ios-simulator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ios-simulator
-description: "Manages iOS Simulator devices and tests app behavior using xcrun simctl. Covers device lifecycle (create, boot, shutdown, erase, delete), app install and launch, push notification simulation, location simulation, permission grants via privacy subcommand, deep link testing via openurl, status bar overrides, screenshot and video recording, log streaming with os_log filtering, get_app_container paths, and #if targetEnvironment(simulator) compile-time checks. Use when creating or managing simulator devices, testing push notifications without APNs, simulating GPS locations, granting or resetting privacy permissions, capturing screenshots or screen recordings from the command line, streaming device logs, debugging simulator boot failures, troubleshooting CoreSimulator issues, or checking simulator hardware limitations."
+description: "Manages iOS Simulator devices and app tests with xcrun simctl: lifecycle, install/launch, push and location simulation, privacy permissions, deep links, status-bar overrides, screenshots/video, log streaming, app containers, and targetEnvironment(simulator). Use when scripting Simulator workflows, debugging CoreSimulator boot failures, or deciding which hardware, performance, networking, memory-pressure, and security behaviors require a physical device."
 ---
 
 # iOS Simulator
@@ -372,9 +372,7 @@ Do not classify "iCloud sync" as a single hardware-only item. Split it explicitl
 | Automatic iCloud sync behavior | Not fully simulated — validate notification-triggered sync, real account/device propagation, conflicts, and background behavior on hardware |
 | Cellular network conditions | No — use Network Link Conditioner on Mac |
 
-Treat Simulator performance as a functional smoke signal only. When answering performance-boundary questions, explicitly name CPU throughput/general processing speed and networking throughput/latency alongside graphics, Metal shader correctness, memory bandwidth, frame timing, memory pressure, Jetsam behavior, and thermal behavior.
-
-Use this minimum wording in release-checklist answers: "Simulator is not an accurate performance proxy for processing/CPU, graphics/Metal, memory, networking throughput/latency, Metal GPU behavior, frame timing, memory pressure/Jetsam, or thermal behavior." If a prompt only names "Metal performance," still include processing, memory, and networking in the device-verification list.
+Treat Simulator performance as a functional smoke signal only. Device verification must cover CPU processing, networking throughput/latency, graphics and Metal behavior, memory bandwidth/pressure and Jetsam, frame timing, and thermals—even when the reported concern names only one category.
 
 ## Common Mistakes
 

--- a/skills/mapkit/SKILL.md
+++ b/skills/mapkit/SKILL.md
@@ -156,23 +156,15 @@ position = .rect(MKMapRect(...))
 
 ### Map Style
 
-```swift
-.mapStyle(.standard)                                        // Default road map
-.mapStyle(.standard(elevation: .realistic, showsTraffic: true))
-.mapStyle(.imagery)                                         // Satellite
-.mapStyle(.imagery(elevation: .realistic))                  // 3D satellite
-.mapStyle(.hybrid)                                          // Satellite + labels
-.mapStyle(.hybrid(elevation: .realistic, showsTraffic: true))
-```
+Default to `.standard`; select `.imagery` or `.hybrid`, realistic elevation,
+traffic, and point-of-interest filtering only when the feature requires them.
+See [Complete Map View Setup](references/mapkit-patterns.md#complete-map-view-setup).
 
 ### Map Interaction Modes
 
-```swift
-.mapInteractionModes(.all)           // Default: pan, zoom, rotate, pitch
-.mapInteractionModes(.pan)           // Pan only
-.mapInteractionModes([.pan, .zoom])  // Pan and zoom
-.mapInteractionModes([])             // Static map (no interaction)
-```
+Keep `.all` for an interactive map. Restrict modes only for intentional gesture
+coordination; use `[]` for a static embedded map. See
+[Map in a List or ScrollView](references/mapkit-patterns.md#map-in-a-list-or-scrollview).
 
 ### Map Selection
 
@@ -426,17 +418,8 @@ func getETA(from source: MKMapItem, to destination: MKMapItem) async throws -> T
 
 ### Cycling Directions (iOS 14+)
 
-```swift
-func getCyclingDirections(to destination: MKMapItem) async throws -> MKRoute? {
-    let request = MKDirections.Request()
-    request.source = MKMapItem.forCurrentLocation()
-    request.destination = destination
-    request.transportType = .cycling
-    let directions = MKDirections(request: request)
-    let response = try await directions.calculate()
-    return response.routes.first
-}
-```
+Use `.cycling` as the request transport type; see the complete
+[cycling route](references/mapkit-patterns.md#cycling-directions-ios-14) example.
 
 ## PlaceDescriptor (iOS 26+)
 

--- a/skills/musickit/SKILL.md
+++ b/skills/musickit/SKILL.md
@@ -7,11 +7,12 @@ description: "Integrate Apple Music playback, catalog search, and Now Playing me
 
 Search the Apple Music catalog, manage playback with `ApplicationMusicPlayer`,
 check subscriptions, and publish Now Playing metadata via `MPNowPlayingInfoCenter`
-and `MPRemoteCommandCenter`. Targets Swift 6.3 / iOS 26+.
+and `MPRemoteCommandCenter`.
 
 ## Contents
 
 - [Setup](#setup)
+- [Workflow](#workflow)
 - [Authorization](#authorization)
 - [Catalog Search](#catalog-search)
 - [Subscription Checks](#subscription-checks)
@@ -22,6 +23,14 @@ and `MPRemoteCommandCenter`. Targets Swift 6.3 / iOS 26+.
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
 - [References](#references)
+
+## Workflow
+
+1. Verify the MusicKit App Service, bundle identifier, purpose string, and background-audio mode before debugging code.
+2. Request authorization, then model every non-authorized state explicitly.
+3. Search or load catalog content and check `MusicSubscription.current` before queueing playback.
+4. Choose `ApplicationMusicPlayer` for app-scoped playback; wire Now Playing and remote commands only when the app owns those surfaces.
+5. Test authorized, denied, unsubscribed, offline, queue failure, interruption, and track-change states. Fix the smallest failing layer, restore the fixture, and rerun the same state matrix.
 
 ## Setup
 
@@ -302,89 +311,13 @@ func enableScrubbing() {
 
 ## Common Mistakes
 
-### DON'T: Skip MusicKit App Service setup or usage description
-
-Without the MusicKit App Service on the app's explicit bundle ID, automatic
-developer token generation for Apple Music API requests is not configured.
-Without `NSAppleMusicUsageDescription`, the app cannot access the user's media
-library on Apple platforms that require the purpose string.
-
-```swift
-// WRONG: MusicKit App Service not enabled for this bundle ID
-
-// CORRECT: Enable MusicKit App Service in the developer portal,
-// set the matching bundle ID, then add NSAppleMusicUsageDescription.
-let status = await MusicAuthorization.request()
-```
-
-### DON'T: Forget to check subscription before playback
-
-Attempting to play catalog content without a subscription silently fails or throws.
-
-```swift
-// WRONG
-func play(_ song: Song) async throws {
-    player.queue = [song]
-    try await player.play() // Fails if no subscription
-}
-
-// CORRECT
-func play(_ song: Song) async throws {
-    let sub = try await MusicSubscription.current
-    guard sub.canPlayCatalogContent else {
-        showSubscriptionOffer()
-        return
-    }
-    player.queue = [song]
-    try await player.play()
-}
-```
-
-### DON'T: Use SystemMusicPlayer when you mean ApplicationMusicPlayer
-
-`SystemMusicPlayer` controls the global Music app queue. Changes affect the user's
-Music app state. Use `ApplicationMusicPlayer` for app-scoped playback.
-
-```swift
-// WRONG: Modifies the user's Music app queue
-let player = SystemMusicPlayer.shared
-
-// CORRECT: App-scoped playback
-let player = ApplicationMusicPlayer.shared
-```
-
-### DON'T: Forget to update Now Playing info when track changes
-
-Stale metadata on the Lock Screen confuses users. Update Now Playing info
-every time the current track changes.
-
-```swift
-// WRONG: Set once and forget
-updateNowPlaying(title: firstSong.title, ...)
-
-// CORRECT: Update on every track change
-func onTrackChanged(_ song: Song) {
-    updateNowPlaying(
-        title: song.title,
-        artist: song.artistName,
-        duration: song.duration ?? 0,
-        elapsed: 0
-    )
-}
-```
-
-### DON'T: Register remote commands without handling them
-
-Registering a command but returning `.commandFailed` breaks Lock Screen controls.
-Disable commands you do not support instead.
-
-```swift
-// WRONG
-center.skipForwardCommand.addTarget { _ in .commandFailed }
-
-// CORRECT
-center.skipForwardCommand.isEnabled = false
-```
+| Mistake | Fix |
+|---|---|
+| Debugging authorization before configuring the App Service and purpose string | Verify service, bundle ID, and `NSAppleMusicUsageDescription` first. |
+| Queueing catalog content without a subscription gate | Check `canPlayCatalogContent`; offer subscription only when `canBecomeSubscriber`. |
+| Using `SystemMusicPlayer` for app-owned playback | Use `ApplicationMusicPlayer`; the system player changes the Music app's global queue. |
+| Publishing Now Playing metadata once | Refresh it on track, duration, rate, and elapsed-time changes. |
+| Registering unsupported remote commands | Disable them; supported handlers must perform the action and return `.success`. |
 
 ## Review Checklist
 

--- a/skills/natural-language/SKILL.md
+++ b/skills/natural-language/SKILL.md
@@ -8,7 +8,6 @@ description: "Tokenize, tag, and analyze natural language text using Apple's Nat
 Analyze natural language text for tokenization, part-of-speech tagging, named
 entity recognition, sentiment analysis, language identification, and word/sentence
 embeddings. Translate text between languages with the Translation framework.
-Targets Swift 6.3 / iOS 26+.
 
 > This skill covers two related frameworks: **NaturalLanguage** (`NLTokenizer`, `NLTagger`, `NLEmbedding`) for on-device text analysis, and **Translation** (`TranslationSession`, `LanguageAvailability`) for language translation.
 

--- a/skills/paperkit/SKILL.md
+++ b/skills/paperkit/SKILL.md
@@ -7,11 +7,12 @@ description: "Add drawings, shapes, and a consistent markup experience using Pap
 
 > **Beta-sensitive.** PaperKit is new in iOS/iPadOS 26, macOS 26, and visionOS 26. API surface may change. Verify details against current Apple documentation before shipping.
 
-PaperKit provides a unified markup experience — the same framework powering markup in Notes, Screenshots, QuickLook, and Journal. It combines PencilKit drawing with structured markup elements (shapes, text boxes, images, lines) in a single canvas managed by `PaperMarkupViewController`. Requires Swift 6.3 and the iOS 26+ SDK.
+PaperKit combines PencilKit drawing with structured markup elements such as shapes, text, images, and lines in a canvas managed by `PaperMarkupViewController`.
 
 ## Contents
 
 - [Setup](#setup)
+- [Workflow](#workflow)
 - [PaperMarkupViewController](#papermarkupviewcontroller)
 - [PaperMarkup Data Model](#papermarkup-data-model)
 - [Insertion Controllers](#insertion-controllers)
@@ -21,6 +22,16 @@ PaperKit provides a unified markup experience — the same framework powering ma
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
 - [References](#references)
+
+## Workflow
+
+1. Choose the document bounds, supported `FeatureSet`, and persistence version before constructing UI.
+2. Create `PaperMarkup`, embed `PaperMarkupViewController`, and keep the controller, tool picker, and insertion controller alive for the view lifetime.
+3. Use the platform-appropriate insertion surface and keep PencilKit drawing inside the PaperKit document boundary.
+4. Save off the main thread, retain a thumbnail for forward-incompatible content, and test round-trip loading with the same feature set.
+5. On failure, restore the original document bytes, fix the feature-set/version/controller mismatch, and rerun edit, save, relaunch, load, thumbnail fallback, and undo checks.
+
+Load [references/paperkit-patterns.md](references/paperkit-patterns.md) for full platform setup, tool picker wiring, persistence, thumbnails, custom feature sets, programmatic construction, and migration.
 
 ## Setup
 
@@ -398,79 +409,13 @@ struct DocumentMarkupScreen: View {
 
 ## Common Mistakes
 
-### Mismatched FeatureSets
-
-```swift
-// DON'T
-let paperVC = PaperMarkupViewController(markup: m, supportedFeatureSet: .latest)
-let editVC = MarkupEditViewController(supportedFeatureSet: .version1, additionalActions: [])
-
-// DO — use the same FeatureSet for both
-let features = FeatureSet.latest
-let paperVC = PaperMarkupViewController(markup: m, supportedFeatureSet: features)
-let editVC = MarkupEditViewController(supportedFeatureSet: features, additionalActions: [])
-```
-
-### Ignoring Content Version on Load
-
-```swift
-// DON'T
-let markup = try PaperMarkup(dataRepresentation: data)
-paperVC.markup = markup
-
-// DO — check version compatibility
-let markup = try PaperMarkup(dataRepresentation: data)
-if markup.featureSet.isSubset(of: paperVC.supportedFeatureSet) {
-    paperVC.markup = markup
-} else {
-    showVersionMismatchAlert()
-}
-```
-
-### Blocking Main Thread with Serialization
-
-```swift
-// DON'T — dataRepresentation() is async, don't try to work around it
-
-// DO — save from an async context
-func paperMarkupViewControllerDidChangeMarkup(_ controller: PaperMarkupViewController) {
-    guard let markup = controller.markup else { return }
-    Task {
-        let data = try await markup.dataRepresentation()
-        try data.write(to: fileURL)
-    }
-}
-```
-
-### Forgetting to Retain the Tool Picker
-
-```swift
-// DON'T — local variable gets deallocated
-func viewDidLoad() {
-    let toolPicker = PKToolPicker()
-    toolPicker.addObserver(paperVC)
-}
-
-// DO — store as instance property
-var toolPicker: PKToolPicker!
-```
-
-### Wrong Insertion Controller for Platform
-
-```swift
-// DON'T — treat MarkupEditViewController as unavailable on Mac Catalyst
-
-// DO — use the right UI for the presentation style
-#if os(macOS)
-let toolbar = MarkupToolbarViewController(supportedFeatureSet: features)
-#elseif targetEnvironment(macCatalyst)
-// Catalyst supports both: toolbar-style UI or UIKit popover insertion.
-let toolbar = MarkupToolbarViewController(supportedFeatureSet: features)
-let editVC = MarkupEditViewController(supportedFeatureSet: features, additionalActions: [])
-#else
-let editVC = MarkupEditViewController(supportedFeatureSet: features, additionalActions: [])
-#endif
-```
+| Mistake | Fix |
+|---|---|
+| View, insertion UI, and saved document use mismatched feature sets | Choose one supported `FeatureSet` and use it across the editing session. |
+| Loaded content is assigned without a version check | Verify `markup.featureSet.isSubset(of: supportedFeatureSet)` or show the saved thumbnail/fallback. |
+| Serialization blocks UI or overlaps unsafely | Await `dataRepresentation()` off the interaction path and debounce autosaves. |
+| Tool picker is a local variable | Retain it for the controller/view lifetime. |
+| Wrong insertion surface for the platform | Use `MarkupToolbarViewController` on macOS; use `MarkupEditViewController` on UIKit, with Catalyst supporting either presentation. |
 
 ## Review Checklist
 

--- a/skills/pencilkit/SKILL.md
+++ b/skills/pencilkit/SKILL.md
@@ -6,8 +6,7 @@ description: "Add Apple Pencil drawing with PKCanvasView, PKToolPicker, PKDrawin
 # PencilKit
 
 Capture Apple Pencil and finger input using `PKCanvasView`, manage drawing
-tools with `PKToolPicker`, serialize drawings with `PKDrawing`, and wrap
-PencilKit in SwiftUI. Targets Swift 6.3 / iOS 26+.
+tools with `PKToolPicker`, serialize drawings with `PKDrawing`, and wrap PencilKit in SwiftUI.
 
 ## Contents
 

--- a/skills/permissionkit/SKILL.md
+++ b/skills/permissionkit/SKILL.md
@@ -9,9 +9,7 @@ description: "Create child communication safety experiences using PermissionKit 
 > and availability against the current Xcode 26 SDK before shipping.
 
 Request permission from a parent or guardian to modify a child's communication
-rules. PermissionKit creates communication safety experiences that let children
-ask for exceptions to communication limits set by their parents. Targets
-Swift 6.3 / iOS 26+.
+rules. PermissionKit creates communication safety experiences that let children ask for exceptions to communication limits set by their parents.
 
 PermissionKit communication experiences are available only through iMessage.
 Use it for parent/guardian approval flows, not as a general in-app contact
@@ -352,111 +350,13 @@ for await response in AskCenter.shared.responses(for: SignificantAppUpdateTopic.
 
 ## Common Mistakes
 
-### DON'T: Treat known-handle checks as enabled-limits checks
-
-`isKnownHandle(_:)` and `knownHandles(in:)` only classify handles. They do not
-replace handling `.communicationLimitsNotEnabled` from `ask(_:in:)`.
-
-```swift
-// WRONG: Assuming a handle lookup proves active limits
-let isKnown = await CommunicationLimits.current.isKnownHandle(handle)
-if !isKnown {
-    try await AskCenter.shared.ask(question, in: viewController)
-}
-
-// CORRECT: Handle the case where limits are not enabled
-do {
-    try await AskCenter.shared.ask(question, in: viewController)
-} catch AskError.communicationLimitsNotEnabled {
-    // Communication limits not active -- continue with normal app flow.
-    allowCommunication()
-} catch {
-    handleError(error)
-}
-```
-
-### DON'T: Ignore AskError cases
-
-Each error case requires different handling.
-
-```swift
-// WRONG: Catch-all with no user feedback
-do {
-    try await AskCenter.shared.ask(question, in: viewController)
-} catch {
-    print(error)
-}
-
-// CORRECT: Handle each case
-do {
-    try await AskCenter.shared.ask(question, in: viewController)
-} catch let error as AskError {
-    switch error {
-    case .communicationLimitsNotEnabled:
-        allowCommunication()
-    case .contactSyncNotSetup:
-        showContactSyncPrompt()
-    case .invalidQuestion:
-        showInvalidQuestionAlert()
-    case .notAvailable:
-        showUnavailableMessage()
-    case .systemError(let underlying):
-        showSystemError(underlying)
-    case .unknown:
-        showGenericError()
-    @unknown default:
-        break
-    }
-}
-```
-
-### DON'T: Create questions with empty handles
-
-A question with no handles or person information is invalid.
-
-```swift
-// WRONG: Empty handles array
-let question = PermissionQuestion<CommunicationTopic>(handles: [])  // Invalid
-
-// CORRECT: Provide at least one handle
-let handle = CommunicationHandle(value: "+1234567890", kind: .phoneNumber)
-let question = PermissionQuestion<CommunicationTopic>(handle: handle)
-```
-
-### DON'T: Forget to observe responses and pending states
-
-Presenting a question without listening for the response means you never know
-if the parent approved. A child can also cancel the send flow, so do not wait
-forever for a response to every question.
-
-```swift
-// WRONG: Fire and forget
-try await AskCenter.shared.ask(question, in: viewController)
-
-// CORRECT: Observe responses
-Task {
-    for await response in AskCenter.shared.responses(for: CommunicationTopic.self) {
-        handleResponse(response)
-    }
-}
-try await AskCenter.shared.ask(question, in: viewController)
-```
-
-### DON'T: Use deprecated CommunicationLimitsButton
-
-Use `PermissionButton` instead of the deprecated `CommunicationLimitsButton`.
-
-```swift
-// WRONG: Deprecated
-CommunicationLimitsButton(question: question) {
-    Text("Ask Permission")
-}
-
-// CORRECT: Use PermissionButton
-PermissionButton(question: question) {
-    Text("Ask Permission")
-}
-```
+| Mistake | Fix |
+|---|---|
+| Known-handle lookup is treated as proof that limits are enabled | Handle `.communicationLimitsNotEnabled` from the ask operation as the normal unconfigured path. |
+| `AskError` is collapsed into one message | Distinguish limits-disabled, contact-sync, invalid-question, unavailable, system, and unknown cases. |
+| Question has no handle or person information | Validate at least one meaningful communication target before presentation. |
+| Ask is fire-and-forget | Observe response and pending state, while allowing child cancellation/abandonment. |
+| Deprecated `CommunicationLimitsButton` is used | Use `PermissionButton`. |
 
 ## Review Checklist
 

--- a/skills/photokit/SKILL.md
+++ b/skills/photokit/SKILL.md
@@ -247,74 +247,17 @@ Omitting a required key causes a runtime crash when the permission dialog would 
 
 ## Camera Capture Basics
 
-Manage camera sessions in a dedicated `@Observable` model. The representable view only displays the preview. See [references/camera-capture.md](references/camera-capture.md) for complete patterns.
+Own each capture session in a dedicated controller and serialize configuration, `startRunning()`, and `stopRunning()` on the same non-main executor. Never mix main-actor configuration with detached start/stop tasks: `beginConfiguration()`/`commitConfiguration()` and session state changes must not race. The representable view only displays the preview.
 
 ### Minimal Camera Manager
 
-```swift
-import AVFoundation
+Load [Camera Capture](references/camera-capture.md) for the serialized-controller pattern, photo/video delegates, focus, torch, orientation, and scanning. The critical lifecycle is:
 
-@available(iOS 17.0, *)
-@Observable
-@MainActor
-final class CameraManager {
-    let session = AVCaptureSession()
-    private let photoOutput = AVCapturePhotoOutput()
-    private var currentDevice: AVCaptureDevice?
-
-    var isRunning = false
-    var capturedImage: Data?
-
-    func configure() async {
-        guard await requestCameraAccess() else { return }
-
-        session.beginConfiguration()
-        session.sessionPreset = .photo
-
-        // Add camera input
-        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera,
-                                                    for: .video,
-                                                    position: .back) else { return }
-        currentDevice = device
-
-        guard let input = try? AVCaptureDeviceInput(device: device),
-              session.canAddInput(input) else { return }
-        session.addInput(input)
-
-        // Add photo output
-        guard session.canAddOutput(photoOutput) else { return }
-        session.addOutput(photoOutput)
-
-        session.commitConfiguration()
-    }
-
-    func start() {
-        guard !session.isRunning else { return }
-        Task.detached { [session] in
-            session.startRunning()
-        }
-        isRunning = true
-    }
-
-    func stop() {
-        guard session.isRunning else { return }
-        Task.detached { [session] in
-            session.stopRunning()
-        }
-        isRunning = false
-    }
-
-    private func requestCameraAccess() async -> Bool {
-        let status = AVCaptureDevice.authorizationStatus(for: .video)
-        if status == .notDetermined {
-            return await AVCaptureDevice.requestAccess(for: .video)
-        }
-        return status == .authorized
-    }
-}
-```
-
-Start and stop `AVCaptureSession` on a background queue. The `startRunning()` and `stopRunning()` methods are synchronous and block the calling thread.
+1. Request access outside the session configuration transaction.
+2. On the capture executor, call `beginConfiguration()` and immediately install `defer { commitConfiguration() }` so every early exit balances the transaction.
+3. Add inputs and outputs only after `canAddInput`/`canAddOutput` checks.
+4. Start or stop on that same executor, then publish UI state on the main actor only after the synchronous call returns.
+5. On failure, stop, restore a fresh session fixture, fix the configuration, and rerun authorization, background/foreground, interruption, and capture checks.
 
 ### Camera Preview in SwiftUI
 
@@ -474,7 +417,7 @@ Use `.original` for photos and artwork. Use `.template` for icons that should ad
 **DO:** Check `AVCaptureDevice.authorizationStatus(for: .video)` and handle `.denied`/`.restricted`.
 
 **DON'T:** Call `session.startRunning()` on the main thread.
-**DO:** Dispatch to a background thread with `Task.detached` or a dedicated serial queue.
+**DO:** Run it on the same dedicated serial executor that owns configuration and stop operations.
 *Why:* `startRunning()` is a synchronous blocking call that can take hundreds of milliseconds while the hardware initializes.
 
 **DON'T:** Create `AVCaptureSession` inside a `UIViewRepresentable`.

--- a/skills/photokit/evals/evals.json
+++ b/skills/photokit/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "photokit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Review a SwiftUI photo-import grid that requests full photo-library access before presenting a picker, loads each selected 48 MP image directly into UIImage, and does the work inline from the view update. Give a privacy-preserving, memory-safe correction plan.",
+      "expected_output": "A focused PhotoKit review that uses the system picker without unnecessary library permission, loads selected items asynchronously, downsamples before display, and distinguishes picker access from custom-library access.",
+      "files": [],
+      "expectations": [
+        "Recommends PhotosPicker or PHPickerViewController for user-selected media instead of UIImagePickerController.",
+        "States that the system picker does not require photo-library permission merely to browse and return selected items.",
+        "Uses loadTransferable(type:) asynchronously and handles nil or thrown decode failures.",
+        "Downsamples large image data with CGImageSource before creating display-sized images.",
+        "Requests read-write access only for a custom library browser or other full-library reads and handles limited access.",
+        "Mentions the appropriate photo-library usage-description key only when explicit access is actually needed."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Review an AVCaptureSession controller that calls beginConfiguration() on the main actor, can return before commitConfiguration(), starts the session in Task.detached, and stops it from another queue when the SwiftUI view disappears. Provide a corrected lifecycle design.",
+      "expected_output": "A camera-session correction that serializes configuration and start/stop operations on one non-main executor, balances configuration transactions, checks addability, and keeps the representable limited to preview display.",
+      "files": [],
+      "expectations": [
+        "Requires one dedicated serial executor or queue to own configuration, startRunning(), and stopRunning().",
+        "Rejects mixing main-actor configuration with detached or unrelated-queue start and stop calls.",
+        "Balances beginConfiguration() with commitConfiguration(), including early failures, using defer or an equivalent guaranteed transaction boundary.",
+        "Checks canAddInput and canAddOutput before mutating the session graph.",
+        "Requests camera permission before entering the configuration transaction.",
+        "Keeps AVCaptureSession ownership outside UIViewRepresentable and limits the representable to the preview layer."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "An iOS media feature needs user-selected photos, a custom all-assets browser, camera capture, remote thumbnail caching, and video playback. Explain which PhotoKit guidance applies directly and where adjacent framework guidance should take over.",
+      "expected_output": "A boundary-aware media plan that owns PhotosPicker, explicit library access, camera capture, and display-sized image handling while routing playback and production remote-image caching to the appropriate adjacent guidance.",
+      "files": [],
+      "expectations": [
+        "Keeps PhotosPicker or PHPickerViewController selection and PhotosPickerItem loading in PhotoKit scope.",
+        "Keeps PHPhotoLibrary authorization and limited-library handling in PhotoKit scope for the custom asset browser.",
+        "Keeps AVCaptureSession camera configuration and capture lifecycle in PhotoKit's camera guidance.",
+        "Routes detailed AVPlayer or playback-session behavior to AVKit or AVFoundation playback guidance.",
+        "Routes production remote-image cache architecture to dedicated image-loading or networking guidance while retaining downsampling advice.",
+        "Does not request full photo-library access for the picker-only path."
+      ]
+    }
+  ]
+}

--- a/skills/photokit/references/camera-capture.md
+++ b/skills/photokit/references/camera-capture.md
@@ -1,6 +1,18 @@
 # Camera Capture
 
-Complete patterns for AVCaptureSession setup, photo capture, video recording, and camera features in SwiftUI. All patterns use a dedicated `@Observable` model that owns the session; the SwiftUI view only displays the preview and triggers actions.
+Patterns for AVCaptureSession setup, photo capture, video recording, and camera features in SwiftUI. Treat all snippets below as operations on one dedicated serial capture executor. Configuration, `startRunning()`, and `stopRunning()` must never race or be split between `@MainActor` and unstructured detached tasks. UI state is published on the main actor only after the capture operation completes.
+
+Every configuration transaction must balance even on early exit:
+
+```swift
+session.beginConfiguration()
+defer { session.commitConfiguration() }
+
+guard session.canAddInput(input) else { throw CameraError.cannotAddInput }
+session.addInput(input)
+```
+
+Use an actor backed by a serial executor or a dedicated serial dispatch queue for the complete controller. Do not copy the older `Task.detached` fragments in isolation; migrate their bodies onto that controller's executor and update observable state after completion.
 
 ---
 

--- a/skills/realitykit/SKILL.md
+++ b/skills/realitykit/SKILL.md
@@ -32,8 +32,7 @@ understanding, and gesture-based interactions. Targets Swift 6.3 / iOS 26+.
 
 ### Device Requirements
 
-AR features require devices with an A9 chip or later. Always check
-`ARWorldTrackingConfiguration.isSupported` before presenting AR UI.
+Check the exact AR configuration's `isSupported` value before presenting AR UI.
 
 ```swift
 import ARKit
@@ -278,23 +277,9 @@ virtual entity picking, not ARKit surface detection.
 
 ### Per-Frame Updates
 
-Subscribe to scene update events for continuous processing:
-
-```swift
-RealityView { content in
-    let entity = ModelEntity(
-        mesh: .generateSphere(radius: 0.05),
-        materials: [SimpleMaterial(color: .yellow, isMetallic: false)]
-    )
-    entity.position = [0, 0, -0.5]
-    content.add(entity)
-
-    _ = content.subscribe(to: SceneEvents.Update.self) { event in
-        let time = Float(event.deltaTime)
-        entity.position.y += sin(Float(Date().timeIntervalSince1970)) * time * 0.1
-    }
-}
-```
+Subscribe to `SceneEvents.Update` for continuous scene work rather than driving
+RealityKit with a SwiftUI timer. Keep the subscription alive and use
+`event.deltaTime`; see [Entity Animations](references/realitykit-patterns.md#entity-animations).
 
 ### Platform Boundaries
 
@@ -320,36 +305,8 @@ explicit migration to RealityKit, not a mixed scene graph.
 
 ### DON'T: Skip AR capability checks
 
-Not all devices support AR. Showing a black camera view with no feedback
-confuses users.
-
-```swift
-// WRONG -- no device check
-struct MyARView: View {
-    var body: some View {
-        RealityView { content in
-            // Fails silently on unsupported devices
-        }
-    }
-}
-
-// CORRECT -- check support and show fallback
-struct MyARView: View {
-    var body: some View {
-        if ARWorldTrackingConfiguration.isSupported {
-            RealityView { content in
-                // AR content
-            }
-        } else {
-            ContentUnavailableView(
-                "AR Not Supported",
-                systemImage: "arkit",
-                description: Text("This device does not support AR.")
-            )
-        }
-    }
-}
-```
+Use the configuration-specific support check from Setup before presenting AR.
+Show non-AR content or an explicit unavailable state when it fails.
 
 ### DON'T: Load heavy models synchronously
 

--- a/skills/relevancekit/SKILL.md
+++ b/skills/relevancekit/SKILL.md
@@ -421,31 +421,11 @@ Call this whenever relevance data changes -- not only during timeline refreshes.
 
 ### Previewing Relevant Widgets
 
-Use Xcode previews to verify appearance without simulating real conditions.
-
-```swift
-// Preview with sample entries
-#Preview("Events", widget: MyRelevantWidget.self, relevanceEntries: {
-    [EventEntry(event: .surfing), EventEntry(event: .meditation)]
-})
-
-// Preview with relevance configurations
-#Preview("Relevance", widget: MyRelevantWidget.self, relevance: {
-    WidgetRelevance([
-        WidgetRelevanceAttribute(configuration: MyIntent(event: .surfing),
-                                 context: .date(Date(), kind: .scheduled))
-    ])
-})
-
-// Preview with the full provider
-#Preview("Provider", widget: MyRelevantWidget.self,
-         relevanceProvider: MyRelevanceProvider())
-```
-
-### Testing
-
-Enable **WidgetKit Developer Mode** in Settings > Developer on the watch to
-bypass Smart Stack rotation limits during development.
+Use the entry, relevance-configuration, and full-provider recipes in
+[Preview Recipes](references/relevancekit-patterns.md#preview-recipes). Enable
+WidgetKit Developer Mode on the watch, test permissions granted and denied, and
+finish on a physical Apple Watch; see
+[Testing Tips](references/relevancekit-patterns.md#testing-tips).
 
 ## Common Mistakes
 

--- a/skills/scenekit/SKILL.md
+++ b/skills/scenekit/SKILL.md
@@ -5,10 +5,7 @@ description: "Maintain and extend existing SceneKit 3D scenes and visualizations
 
 # SceneKit
 
-Apple's high-level 3D rendering framework for maintaining existing scenes and
-visualizations on iOS using Swift 6.3. Provides a node-based scene graph,
-built-in geometry primitives, physically based materials, lighting, animation,
-and physics.
+Maintain existing node-based 3D scenes, materials, lighting, animation, and physics. Use RealityKit for new projects or major modernization work.
 
 **Deprecation notice (WWDC 2025):** SceneKit is officially deprecated across all
 Apple platforms and is now in maintenance mode (critical bug fixes only). Existing

--- a/skills/sensorkit/SKILL.md
+++ b/skills/sensorkit/SKILL.md
@@ -5,11 +5,7 @@ description: "Access research-grade sensor data using SensorKit for approved stu
 
 # SensorKit
 
-Collect research-grade sensor data from iOS and watchOS devices for approved
-research studies. SensorKit provides access to ambient light, motion, device
-usage, keyboard metrics, visits, phone/messaging usage, speech metrics, face
-metrics, wrist temperature, heart rate, ECG, and PPG data. Targets
-Swift 6.3 / iOS 26+.
+Collect research-grade sensor data from iOS and watchOS devices for approved research studies. Choose the exact `SRSensor` from the catalog below and verify its individual availability.
 
 **SensorKit is restricted to Apple-approved research studies.** Apps must submit
 a research proposal to Apple and receive the `com.apple.developer.sensorkit.reader.allow`

--- a/skills/shareplay-activities/SKILL.md
+++ b/skills/shareplay-activities/SKILL.md
@@ -7,7 +7,7 @@ description: "Build shared real-time experiences using GroupActivities and Share
 
 Build shared real-time experiences using the GroupActivities framework. SharePlay
 connects people over FaceTime, Messages, AirDrop, and nearby visionOS sharing,
-synchronizing media playback, app state, or custom data. Targets Swift 6.3 / iOS 26+.
+synchronizing media playback, app state, or custom data.
 
 ## Contents
 
@@ -362,20 +362,8 @@ Task {
 
 ### DON'T: Forget to call session.join()
 
-```swift
-// WRONG -- session is received but never joined
-for await session in MyActivity.sessions() {
-    self.session = session
-    // Session stays in .waiting state forever
-}
-
-// CORRECT -- join after configuring
-for await session in MyActivity.sessions() {
-    self.session = session
-    self.messenger = GroupSessionMessenger(session: session)
-    session.join()
-}
-```
+Configure the stored session, messenger, and observers, then call `join()`. The
+canonical long-lived manager in Session Lifecycle shows the required order.
 
 ### DON'T: Forget to leave or end sessions
 
@@ -441,29 +429,8 @@ player.play()  // Automatically synced to all participants
 
 ### DON'T: Observe sessions in a view that gets recreated
 
-```swift
-// WRONG -- each time the view appears, a new listener is created
-struct MyView: View {
-    var body: some View {
-        Text("Hello")
-            .task {
-                for await session in MyActivity.sessions() { }
-            }
-    }
-}
-
-// CORRECT -- observe sessions in a long-lived manager
-@Observable
-final class ActivityManager {
-    init() {
-        Task {
-            for await session in MyActivity.sessions() {
-                configureSession(session)
-            }
-        }
-    }
-}
-```
+Own the `sessions()` listener in a long-lived manager, not a recreatable view.
+Use the manager lifecycle shown above and cancel its child tasks on invalidation.
 
 ## Review Checklist
 

--- a/skills/speech-recognition/SKILL.md
+++ b/skills/speech-recognition/SKILL.md
@@ -7,8 +7,7 @@ description: "Transcribe speech to text using Apple's Speech framework. Use when
 
 Transcribe live and pre-recorded audio to text using Apple's Speech framework.
 Covers `SpeechAnalyzer` / `SpeechTranscriber` (iOS 26+) and
-`SFSpeechRecognizer` (iOS 10+). Targets Swift 6.3 / iOS 26+ while preserving
-fallback guidance for apps that support older OS versions.
+`SFSpeechRecognizer` (iOS 10+) fallback guidance.
 
 **Scope boundary:** Use this skill for speech-to-text recognition, speech
 authorization, microphone capture plumbing, and result handling. Hand off text
@@ -269,22 +268,7 @@ state across tasks.
 
 ### Partial vs final results
 
-```swift
-let request = SFSpeechAudioBufferRecognitionRequest()
-request.shouldReportPartialResults = true  // default is true
-
-recognizer.recognitionTask(with: request) { result, error in
-    guard let result else { return }
-
-    if result.isFinal {
-        // Final transcription — recognition is complete
-        let final = result.bestTranscription.formattedString
-    } else {
-        // Partial result — may change as more audio is processed
-        let partial = result.bestTranscription.formattedString
-    }
-}
-```
+With `shouldReportPartialResults`, replace the displayed partial transcript until `SFSpeechRecognitionResult.isFinal` commits it. This is separate from `SpeechTranscriber.Result.isFinal`, whose volatile attributed range must be replaced by the final result for that range. The live example and [references/speechanalyzer-patterns.md](references/speechanalyzer-patterns.md) contain the canonical loops.
 
 ### Accessing alternative transcriptions and confidence
 
@@ -322,145 +306,18 @@ request.contextualStrings = ["SwiftUI", "Xcode", "CloudKit"]
 
 ## Common Mistakes
 
-### Not requesting both speech and microphone authorization
+| Mistake | Fix |
+|---|---|
+| Live audio requests only speech authorization | Require both speech and microphone permission. |
+| Recognizer availability is checked once | Observe delegate availability changes and model loss of service. |
+| Final/error/rollover paths perform different cleanup | Use one `stopTranscribing()` owner for engine stop, tap removal, `endAudio`, and task cancellation. |
+| On-device mode is forced for every locale | Check `supportsOnDeviceRecognition` and provide a fallback. |
+| One `SFSpeechRecognizer` task is used for long-form capture | Prefer SpeechAnalyzer on iOS 26+ or roll bounded segments while preserving committed transcript. |
+| Finishing analyzer input is treated as session completion | Explicitly finalize through the last sample or cancel-and-finish. |
+| Volatile SpeechAnalyzer results are appended | Replace the volatile range until a final result commits it. |
+| A second recognition task starts before the first ends | Cancel/finish the active task and complete cleanup before replacement. |
 
-```swift
-// ❌ DON'T: Only request speech authorization for live audio
-SFSpeechRecognizer.requestAuthorization { status in
-    // Missing microphone permission — audio engine will fail
-    self.startRecording()
-}
-
-// ✅ DO: Request both permissions before recording
-SFSpeechRecognizer.requestAuthorization { status in
-    guard status == .authorized else { return }
-    AVAudioSession.sharedInstance().requestRecordPermission { granted in
-        guard granted else { return }
-        self.startRecording()
-    }
-}
-```
-
-### Not handling availability changes
-
-```swift
-// ❌ DON'T: Assume recognizer stays available after initial check
-let recognizer = SFSpeechRecognizer()!
-// Recognition may fail if network drops or locale changes
-
-// ✅ DO: Monitor availability via delegate
-recognizer.delegate = self
-func speechRecognizer(
-    _ speechRecognizer: SFSpeechRecognizer,
-    availabilityDidChange available: Bool
-) {
-    recordButton.isEnabled = available
-}
-```
-
-### Not stopping the audio engine when recognition ends
-
-```swift
-// ❌ DON'T: Leave audio engine running after recognition finishes
-recognizer.recognitionTask(with: request) { result, error in
-    if result?.isFinal == true {
-        // Audio engine still running, wasting resources and battery
-    }
-}
-
-// ✅ DO: Clean up all audio resources
-recognizer.recognitionTask(with: request) { result, error in
-    if result?.isFinal == true || error != nil {
-        self.audioEngine.stop()
-        self.audioEngine.inputNode.removeTap(onBus: 0)
-        self.recognitionRequest?.endAudio()
-        self.recognitionRequest = nil
-    }
-}
-```
-
-### Assuming on-device recognition is available for all locales
-
-```swift
-// ❌ DON'T: Force on-device without checking support
-let request = SFSpeechAudioBufferRecognitionRequest()
-request.requiresOnDeviceRecognition = true // Ignored unless the recognizer supports it
-
-// ✅ DO: Check support before requiring on-device
-if recognizer.supportsOnDeviceRecognition {
-    request.requiresOnDeviceRecognition = true
-} else {
-    // Fall back to server-based or inform user
-}
-```
-
-### Not handling the one-minute recognition limit
-
-```swift
-// ❌ DON'T: Start one long continuous recognition session
-func startRecording() {
-    // SFSpeechRecognizer tasks can be cut off after about 60 seconds
-}
-
-// ✅ DO: roll the segment before the limit and let cleanup end audio once
-func scheduleRecognitionRollover() {
-    recognitionTimer = Timer.scheduledTimer(withTimeInterval: 55, repeats: false) { [weak self] _ in
-        self?.commitLatestPartialText()
-        self?.stopTranscribing()     // owns endAudio(), tap removal, and task cancellation
-        try? self?.startTranscribing()
-    }
-}
-```
-`SFSpeechRecognitionTask` exposes `finish()`, `cancel()`, `state`, and `error`;
-do not invent task properties such as `recognitionTask` to restart work. Keep
-the active `SFSpeechAudioBufferRecognitionRequest` in your manager and call
-`endAudio()` from one cleanup path only.
-
-### Treating SpeechAnalyzer input completion as session completion
-
-```swift
-// ❌ DON'T: Only finish the AsyncStream and expect result streams to close
-inputBuilder.finish()
-
-// ✅ DO: explicitly finish or cancel the analyzer session
-let lastSampleTime = try await analyzer.analyzeSequence(inputSequence)
-if let lastSampleTime {
-    try await analyzer.finalizeAndFinish(through: lastSampleTime)
-} else {
-    try analyzer.cancelAndFinishNow()
-}
-```
-
-### Duplicating volatile SpeechAnalyzer results
-
-```swift
-// ✅ Replace volatile text with the finalized result for the same audio range
-for try await result in transcriber.results {
-    if result.isFinal {
-        volatileTranscript = AttributedString()
-        finalizedTranscript.append(result.text)
-    } else {
-        volatileTranscript = result.text
-    }
-}
-```
-
-### Creating multiple simultaneous recognition tasks
-
-```swift
-// ❌ DON'T: Start a new task without canceling the previous one
-func startRecording() {
-    recognitionTask = recognizer.recognitionTask(with: request) { ... }
-    // Previous task is still running — undefined behavior
-}
-
-// ✅ DO: Cancel existing task before creating a new one
-func startRecording() {
-    recognitionTask?.cancel()
-    recognitionTask = nil
-    recognitionTask = recognizer.recognitionTask(with: request) { ... }
-}
-```
+Load [references/speechanalyzer-patterns.md](references/speechanalyzer-patterns.md) for complete analyzer finalization and volatile-result code.
 
 ## Review Checklist
 

--- a/skills/storekit/SKILL.md
+++ b/skills/storekit/SKILL.md
@@ -6,19 +6,17 @@ description: "Implement, review, or improve in-app purchases and subscriptions u
 # StoreKit 2 In-App Purchases and Subscriptions
 
 Implement in-app purchases, subscriptions, paywalls, and StoreKit testing using
-StoreKit 2 on iOS 26+. Use the modern Swift-based `Product`, `Transaction`,
+StoreKit 2. Use the modern Swift-based `Product`, `Transaction`,
 `PurchaseAction`, `StoreView`, and `SubscriptionStoreView` APIs. Avoid original
 In-App Purchase APIs (`SKProduct`, `SKPaymentQueue`) unless legacy OS support
 requires them.
 
-When reviewing StoreKit code, explicitly separate "preferred SwiftUI path" from
-"invalid API": `PurchaseAction` is the preferred custom SwiftUI button path, but
-direct `product.purchase(options:)` is still valid for lower-level custom
-StoreKit flows.
+StoreKit views initiate purchases automatically. For custom controls, use
+`PurchaseAction` in SwiftUI, `purchase(confirmIn:options:)` in UIKit/AppKit, and
+`product.purchase(options:)` on watchOS.
 
 ## Contents
 
-- [Implementation Review Minimums](#implementation-review-minimums)
 - [Product Types](#product-types)
 - [Loading Products](#loading-products)
 - [Purchase Flow](#purchase-flow)
@@ -34,33 +32,6 @@ StoreKit flows.
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
 - [References](#references)
-
-## Implementation Review Minimums
-
-When reviewing a paywall, purchase manager, or entitlement gate, include these
-points explicitly:
-
-- Standard SwiftUI paywalls should prefer `StoreView`, `ProductView`, or
-  `SubscriptionStoreView`; custom SwiftUI buy buttons should prefer
-  `PurchaseAction`; direct `product.purchase(options:)` is valid for
-  lower-level custom StoreKit flows.
-- `Transaction.updates` must start at app launch because it catches purchases
-  from other devices, Family Sharing changes, renewals, Ask to Buy approvals,
-  refunds, revocations, and unfinished transactions.
-- Include this entitlement-scope sentence verbatim when reviewing
-  `Transaction.currentEntitlements`: "It covers non-consumables, active or
-  grace-period auto-renewable subscriptions, and non-renewing subscriptions; it
-  does not include consumable purchase or delivery history."
-- Verify every `VerificationResult` before granting access. Deliver or persist
-  the entitlement first, then call `transaction.finish()`.
-- Pending purchases and user cancellations never unlock content; pending Ask to
-  Buy approvals unlock only after a verified transaction arrives through the
-  launch-time listener.
-- Exclude refunded or revoked transactions from active entitlement state and
-  re-check entitlements when refunds or revocations arrive through
-  `Transaction.updates`.
-- Provide a visible restore purchases path and Terms of Service / Privacy
-  Policy links on subscription paywalls.
 
 ## Product Types
 
@@ -97,13 +68,9 @@ for product in products {
 Prefer StoreKit views for standard paywalls because they initiate purchases,
 restore purchases, and display policy controls. For custom SwiftUI purchase
 buttons, prefer `PurchaseAction` from the environment. Use direct
-`product.purchase(options:)` only for lower-level custom flows, and use
-`purchase(confirmIn:options:)` for UIKit or AppKit confirmation. Always handle
-every `PurchaseResult`, verify before access, deliver durably, then finish.
-
-Review wording: do not call `product.purchase(options:)` inherently wrong. Say
-"prefer `PurchaseAction` for SwiftUI buttons; keep `product.purchase(options:)`
-for lower-level custom flows that need direct StoreKit control."
+`product.purchase(options:)` for watchOS, and use `purchase(confirmIn:options:)`
+for UIKit or AppKit confirmation. Always handle every `PurchaseResult`, verify
+before access, deliver durably, then finish.
 
 ```swift
 @Environment(\.purchase) private var purchase
@@ -142,10 +109,6 @@ devices, Family Sharing changes, renewals, Ask to Buy approvals, refunds,
 revocations, and unfinished transactions Apple emits once immediately after
 launch. Keep the task retained for the app lifetime.
 
-In implementation reviews, name the launch-time coverage explicitly: purchases
-made on other devices, Family Sharing changes, subscription renewals, Ask to Buy
-approvals, refunds, revocations, and unfinished transactions.
-
 ```swift
 @main
 struct MyApp: App {
@@ -173,17 +136,11 @@ struct MyApp: App {
 
 ## Entitlement Checking
 
-Use `Transaction.currentEntitlements` for non-consumables, active or grace
-period auto-renewable subscriptions, and non-renewing subscriptions. It excludes
-consumables and consumable delivery history; track consumable fulfillment in
-your own app or server ledger. It also excludes refunded or revoked
-transactions. Use `Transaction.unfinished` for unfinished consumables and
-recovery sweeps. Always check `revocationDate` when processing transactions.
-
-In reviews, include this sentence verbatim: "Transaction.currentEntitlements
-covers non-consumables, active or grace-period auto-renewable subscriptions, and
-non-renewing subscriptions; it does not include consumable purchase or delivery
-history." Do not replace this with only a code sample or a revocation check.
+`Transaction.currentEntitlements` emits non-consumables, active or grace-period
+auto-renewable subscriptions, and the latest non-renewing subscription
+transaction—including finished ones. It excludes consumables and refunded or
+revoked products. Track consumable fulfillment separately, and apply the app's
+expiration policy to non-renewing subscriptions before granting access.
 
 ```swift
 @Observable
@@ -198,6 +155,10 @@ class StoreManager {
         for await result in Transaction.currentEntitlements {
             if case .verified(let transaction) = result,
                transaction.revocationDate == nil {
+                if transaction.productType == .nonRenewing,
+                   transaction.expirationDate.map({ $0 <= .now }) ?? true {
+                    continue
+                }
                 purchased.insert(transaction.productID)
             }
         }
@@ -253,29 +214,14 @@ SubscriptionStoreView(groupID: "YOUR_GROUP_ID")
 
 ### Custom Marketing Content
 
-```swift
-SubscriptionStoreView(groupID: "YOUR_GROUP_ID") {
-    VStack {
-        Image(systemName: "crown.fill").font(.system(size: 60)).foregroundStyle(.yellow)
-        Text("Unlock Premium").font(.largeTitle.bold())
-        Text("Access all features").foregroundStyle(.secondary)
-    }
-}
-.containerBackground(.blue.gradient, for: .subscriptionStore)
-```
+Use the container background and header patterns in
+[SubscriptionStoreView Control Styles](references/storekit-advanced.md#subscriptionstoreview-control-styles).
 
 ### Hierarchical Layout
 
-`SubscriptionOptionGroup`, `SubscriptionOptionSection`, and
-`SubscriptionPeriodGroupSet` are iOS 18+ helper views for organizing options
-inside `SubscriptionStoreView`.
-
-```swift
-SubscriptionStoreView(groupID: "YOUR_GROUP_ID") {
-    SubscriptionPeriodGroupSet()
-}
-.subscriptionStoreControlStyle(.picker)
-```
+Use `SubscriptionOptionGroup`, `SubscriptionOptionSection`, or
+`SubscriptionPeriodGroupSet` to organize iOS 18+ options; see
+[Subscription Group Management](references/storekit-advanced.md#subscription-group-management).
 
 ## StoreView (iOS 17+)
 

--- a/skills/swift-api-design-guidelines/SKILL.md
+++ b/skills/swift-api-design-guidelines/SKILL.md
@@ -390,27 +390,16 @@ For casing edge cases, overload patterns, and tuple/closure naming, see [referen
 
 ## Common Mistakes
 
-1. **Omitting needed argument labels.** Using `remove(position)` instead of `remove(at: position)` when the role of the argument is ambiguous without the label.
-
-2. **Using -ed when -ing is correct.** Applying `stripped()` when the past participle is ungrammatical — use `stripping()` instead. Test: does "a [verb]-ed [noun]" read naturally?
-
-3. **Using verb names for side-effect-free operations.** Naming a nonmutating method `sort()` that returns a new collection — use `sorted()` to signal no mutation.
-
-4. **Naming by type instead of role.** Using `string` instead of `greeting`, or `array` instead of `elements`, when the role would be more informative.
-
-5. **Missing documentation comments.** Leaving public declarations undocumented, or writing summaries that describe the implementation rather than the purpose.
-
-6. **Not documenting non-O(1) computed properties.** Exposing a linear-time computed property without a `Complexity:` note, causing callers to assume O(1) and use it in loops.
-
-7. **Applying form- prefix to verb-based operations.** Writing `formSort()` instead of just `sort()` — the `form` prefix is only for noun-based operations (`formUnion`).
-
-8. **Factory methods without make- prefix.** Naming factory methods as `createIterator()` or `buildBuffer()` instead of `makeIterator()` and `makeBuffer()`.
-
-9. **Repeating type information in names.** Writing `removeElement(cancelButton)` or `stringValue: String` when the type is already evident from context.
-
-10. **Return-type-only overloads.** Defining overloads that differ only in return type, creating ambiguity when the compiler cannot infer the expected type.
-
-11. **Unlabeled tuple members and closure parameters.** Exposing tuples or closures in public API without naming their components, forcing callers to use positional access.
+| Mistake | Correction |
+|---|---|
+| Ambiguous or missing labels | Make the call read grammatically, such as `remove(at:)`. |
+| Wrong mutating/nonmutating form | Use imperative verbs for mutation and a grammatical `-ed`/`-ing` or noun form for copies. |
+| Names describe types or implementation | Name roles and semantic effects. |
+| Public API lacks purpose or complexity docs | Add a concise summary and document non-O(1) properties. |
+| `form` or factory prefixes are misapplied | Reserve `form` for noun operations; use `make` for factories. |
+| Type information is repeated | Remove words already clear from the declaration and context. |
+| Overloads differ only by return type | Add a semantic name or parameter distinction. |
+| Tuple or closure components are positional | Label public components and closure parameters. |
 
 ## Review Checklist
 

--- a/skills/swift-architecture/SKILL.md
+++ b/skills/swift-architecture/SKILL.md
@@ -1,499 +1,134 @@
 ---
 name: swift-architecture
-description: "Select, implement, or migrate between app architecture patterns for Apple platform apps. Use when choosing between MV (Model-View with @Observable), MVVM, MVI, TCA (The Composable Architecture), Clean Architecture, VIPER, or Coordinator patterns; when evaluating architecture fit for a feature's complexity; when migrating from one pattern to another; or when reviewing whether an app's current architecture is appropriate. Scoped to Apple-platform patterns using Swift 6.3, SwiftUI, and UIKit."
+description: "Selects, reviews, and migrates Apple-platform app architectures across MV with Observation, MVVM, MVI, TCA, Clean Architecture, Coordinator, and legacy VIPER. Use when choosing module and dependency boundaries, escalating a feature beyond simple SwiftUI MV, planning incremental architecture migration, or auditing state ownership and test seams."
 ---
 
 # Swift Architecture
 
-Select and implement the right architecture pattern for Apple platform apps built with Swift 6.3 and SwiftUI or UIKit.
+Choose the smallest architecture that makes state ownership, dependencies, side effects, and tests explicit. Default new SwiftUI features to MV; escalate only for observed complexity.
 
 ## Contents
 
 - [Scope Boundary](#scope-boundary)
-- [Architecture Selection](#architecture-selection)
-- [MV Pattern (Model-View with `@Observable`)](#mv-pattern)
-- [MVVM](#mvvm)
-- [MVI (Model-View-Intent)](#mvi)
-- [TCA (The Composable Architecture)](#tca)
-- [Clean Architecture](#clean-architecture)
-- [Coordinator Pattern](#coordinator-pattern)
-- [VIPER](#viper)
-- [Migration Between Patterns](#migration-between-patterns)
+- [Decision Workflow](#decision-workflow)
+- [Pattern Selection](#pattern-selection)
+- [MV Default](#mv-default)
+- [Escalation Signals](#escalation-signals)
+- [Migration](#migration)
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
 - [References](#references)
 
 ## Scope Boundary
 
-This skill owns architecture-level decisions: pattern selection, module
-boundaries, dependency direction, migration/escalation strategy, and structural
-test strategy. It does not own SwiftUI state mechanics; route `@State`,
-`@Bindable`, `@Environment`, edit-sheet/local state, bindings, view composition,
-and `@Observable` MV implementation mechanics to `swiftui-patterns`. Use
-`swiftui-navigation` for `NavigationStack`, `NavigationSplitView`,
-`NavigationPath`, route models, sheets, tabs, and deep-link URL handling;
-`swift-concurrency` for `@MainActor`, default MainActor isolation, `Sendable`,
-strict-concurrency diagnostics, and data-race diagnostics; and `swift-testing`
-for `@Test`, `#expect`, `#require`, fixtures, parameterized tests, mocks, stubs,
-and suite organization.
+This skill owns pattern selection, module boundaries, dependency direction, migration strategy, and architecture-level test seams. Route SwiftUI property-wrapper wiring and view composition to `swiftui-patterns`, navigation APIs and route models to `swiftui-navigation`, isolation diagnostics to `swift-concurrency`, and test syntax/fixtures to `swift-testing`.
 
-## Architecture Selection
+## Decision Workflow
 
-| Pattern | Best For | Complexity | Testability |
-|---------|----------|-----------|-------------|
-| **MV** | Small-to-medium SwiftUI apps, rapid iteration | Low | Moderate |
-| **MVVM** | Medium apps, teams familiar with reactive patterns | Medium | High |
-| **MVI** | Complex state machines, predictable state flow | Medium-High | High |
-| **TCA** | Large apps needing composable features, strong testing | High | Very High |
-| **Clean Architecture** | Enterprise apps, strict separation of concerns | High | Very High |
-| **Coordinator** | Apps with complex navigation flows (UIKit or hybrid) | Medium | High |
-| **VIPER** | Legacy UIKit modules already using VIPER boundaries | Very High | High |
+1. Record the feature's state owner, inputs, outputs, dependencies, side effects, navigation handoffs, and current tests.
+2. Identify the concrete pressure: complex state machine, shared derived state, dependency control, feature composition, team ownership, or UIKit navigation.
+3. Select the smallest pattern that addresses that pressure; write down what it adds and what remains unchanged.
+4. Implement one vertical slice with injected dependencies and observable state transitions.
+5. Run existing behavior tests plus state-transition and dependency-failure tests. If behavior changes, restore the fixture, fix the smallest boundary, and rerun before migrating another slice.
 
-**Default recommendation for new SwiftUI apps:** Start with MV (Model-View
-with `@Observable`). Escalate to MVVM or TCA only when the feature's complexity
-demands it.
+## Pattern Selection
 
-Boundary-split answers should use one `swift-architecture` bucket for
-pattern/module/dependency/migration/test-strategy decisions. Do not add a
-separate architecture-owned "SwiftUI state ownership" bucket; property-wrapper,
-local binding, navigation, concurrency-diagnostic, fixture, and parameterized
-test mechanics are sibling-skill handoffs.
+| Pattern | Choose when | Main cost |
+|---|---|---|
+| MV | SwiftUI feature has straightforward state and orchestration | Logic can drift into large views without decomposition |
+| MVVM | Presentation logic needs an independently testable adapter | Extra layer can become a forwarding shell |
+| MVI | A feature is best modeled as explicit state + intents + reducer/effects | Boilerplate and centralized transition design |
+| TCA | Many composable features need deterministic effects, dependencies, and testing | Framework learning and architectural commitment |
+| Clean Architecture | Large product needs strict dependency direction across domain/data/UI | Protocol and mapping overhead |
+| Coordinator | UIKit or hybrid navigation needs a separate flow owner | Another lifecycle and routing owner |
+| VIPER | Maintaining an existing UIKit module with established VIPER boundaries | Very high ceremony; poor default for new SwiftUI work |
 
-### Decision Framework
+Use Coordinator alongside another state pattern when navigation complexity is the pressure; it is not a replacement for domain/state architecture.
 
-1. **Is the feature a simple CRUD screen?** → MV pattern
-2. **Does the screen have complex business logic separate from the view?** → MVVM
-3. **Do you need deterministic state transitions and side-effect management?** → MVI or TCA
-4. **Is the app large with many independent feature modules?** → TCA or Clean Architecture
-5. **Is navigation complex with deep linking and conditional flows?** → Add Coordinator pattern
+## MV Default
 
-## MV Pattern
-
-The simplest SwiftUI architecture. The view observes `@Observable` models
-directly. No intermediate view model layer.
+Keep views as state expressions and put business operations in observable models and injected services:
 
 ```swift
-import Observation
-import SwiftUI
-
 @MainActor
 @Observable
 final class TripStore {
+    private let client: TripClient
     var trips: [Trip] = []
-    var isLoading = false
     var error: Error?
 
-    private let service: TripService
-
-    init(service: TripService) {
-        self.service = service
-    }
-
-    func loadTrips() async {
-        isLoading = true
-        defer { isLoading = false }
-        do {
-            trips = try await service.fetchTrips()
-        } catch {
-            self.error = error
-        }
-    }
-
-    func deleteTrip(_ trip: Trip) async throws {
-        try await service.delete(trip)
-        trips.removeAll { $0.id == trip.id }
-    }
-}
-
-struct TripsView: View {
-    @State private var store = TripStore(service: .live)
-
-    var body: some View {
-        List(store.trips) { trip in
-            TripRow(trip: trip)
-        }
-        .task { await store.loadTrips() }
-    }
-}
-```
-
-**When MV is enough:** Single-screen features, prototype/MVP, small teams,
-straightforward data flow.
-
-**When to upgrade:** Business logic grows complex, unit testing the view's
-behavior becomes difficult, multiple views need to share and transform the
-same state differently.
-
-## MVVM
-
-Separates view logic into a `ViewModel` that the view observes. The view model
-transforms model data for display and handles user actions.
-
-```swift
-@MainActor
-@Observable
-final class TripListViewModel {
-    private(set) var trips: [TripRowItem] = []
-    private(set) var isLoading = false
-    var searchText = ""
-
-    var filteredTrips: [TripRowItem] {
-        guard !searchText.isEmpty else { return trips }
-        return trips.filter { $0.name.localizedStandardContains(searchText) }
-    }
-
-    private let repository: TripRepository
-
-    init(repository: TripRepository) {
-        self.repository = repository
-    }
-
-    func loadTrips() async {
-        isLoading = true
-        defer { isLoading = false }
-        let models = (try? await repository.fetchAll()) ?? []
-        trips = models.map { TripRowItem(from: $0) }
-    }
-
-    func delete(at offsets: IndexSet) async {
-        let toDelete = offsets.map { filteredTrips[$0] }
-        for item in toDelete {
-            try? await repository.delete(id: item.id)
-        }
-        await loadTrips()
-    }
-}
-
-struct TripRowItem: Identifiable {
-    let id: UUID
-    let name: String
-    let dateRange: String
-
-    init(from trip: Trip) {
-        self.id = trip.id
-        self.name = trip.name
-        self.dateRange = trip.startDate.formatted(.dateTime.month().day())
-            + " – " + trip.endDate.formatted(.dateTime.month().day())
-    }
-}
-
-struct TripListView: View {
-    @State private var viewModel: TripListViewModel
-
-    init(repository: TripRepository) {
-        _viewModel = State(initialValue: TripListViewModel(repository: repository))
-    }
-
-    var body: some View {
-        List {
-            ForEach(viewModel.filteredTrips) { item in
-                Text(item.name)
-            }
-            .onDelete { offsets in
-                Task { await viewModel.delete(at: offsets) }
-            }
-        }
-        .searchable(text: $viewModel.searchText)
-        .task { await viewModel.loadTrips() }
-    }
-}
-```
-
-**Testing a ViewModel:**
-
-```swift
-@Test func filteredTripsMatchesSearch() async {
-    let repo = MockTripRepository(trips: [
-        Trip(name: "Paris"), Trip(name: "Tokyo"), Trip(name: "Paris TX")
-    ])
-    let vm = TripListViewModel(repository: repo)
-    await vm.loadTrips()
-    vm.searchText = "Paris"
-    #expect(vm.filteredTrips.count == 2)
-}
-```
-
-## MVI
-
-Unidirectional data flow: views dispatch **intents**, a **reducer** produces
-new **state**, and **side effects** are handled explicitly.
-
-```swift
-@MainActor
-@Observable
-final class TripListStore {
-    private(set) var state = State()
-
-    struct State {
-        var trips: [Trip] = []
-        var isLoading = false
-        var error: String?
-    }
-
-    enum Intent {
-        case loadTrips
-        case deleteTrip(Trip)
-        case clearError
-    }
-
-    private let service: TripService
-
-    init(service: TripService) {
-        self.service = service
-    }
-
-    func send(_ intent: Intent) {
-        Task { await handle(intent) }
-    }
-
-    private func handle(_ intent: Intent) async {
-        switch intent {
-        case .loadTrips:
-            state.isLoading = true
-            do {
-                state.trips = try await service.fetchTrips()
-            } catch {
-                state.error = error.localizedDescription
-            }
-            state.isLoading = false
-
-        case .deleteTrip(let trip):
-            try? await service.delete(trip)
-            state.trips.removeAll { $0.id == trip.id }
-
-        case .clearError:
-            state.error = nil
-        }
-    }
-}
-```
-
-**Advantages:** Predictable state transitions, easy to log/replay intents,
-clear separation of "what happened" from "what changed."
-
-## TCA
-
-The Composable Architecture (Point-Free) provides composable reducers,
-dependency injection, exhaustive testing, and structured side effects.
-
-Docs: [TCA](https://sosumi.ai/external/https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture)
-
-```swift
-import ComposableArchitecture
-
-@Reducer
-struct TripList {
-    @ObservableState
-    struct State: Equatable {
-        var trips: IdentifiedArrayOf<Trip> = []
-        var isLoading = false
-        var errorMessage: String?
-    }
-
-    enum Action {
-        case onAppear
-        case tripsLoaded([Trip])
-        case tripsFailed(String)
-        case deleteTrip(Trip.ID)
-    }
-
-    @Dependency(\.tripClient) var tripClient
-
-    var body: some ReducerOf<Self> {
-        Reduce { state, action in
-            switch action {
-            case .onAppear:
-                state.isLoading = true
-                state.errorMessage = nil
-                return .run { send in
-                    do {
-                        let trips = try await tripClient.fetchAll()
-                        await send(.tripsLoaded(trips))
-                    } catch {
-                        await send(.tripsFailed(error.localizedDescription))
-                    }
-                }
-            case .tripsLoaded(let trips):
-                state.trips = IdentifiedArray(uniqueElements: trips)
-                state.isLoading = false
-                return .none
-            case .tripsFailed(let message):
-                state.errorMessage = message
-                state.isLoading = false
-                return .none
-            case .deleteTrip(let id):
-                state.trips.remove(id: id)
-                return .run { _ in try await tripClient.delete(id) }
-            }
-        }
-    }
-}
-```
-
-**Use TCA when:** You need deterministic state transitions for complex state
-flows, structured side-effect sequencing, feature composition, strong reducer
-testing, or app-wide dependency injection.
-
-## Clean Architecture
-
-Layers: **Domain** (entities, use cases, repository protocols) → **Data**
-(repository implementations, network, persistence) → **Presentation** (views,
-view models). Dependencies point inward.
-
-```swift
-// Domain layer
-protocol TripRepository: Sendable {
-    func fetchAll() async throws -> [Trip]
-    func save(_ trip: Trip) async throws
-    func delete(id: UUID) async throws
-}
-
-struct FetchUpcomingTripsUseCase: Sendable {
-    private let repository: TripRepository
-
-    init(repository: TripRepository) {
-        self.repository = repository
-    }
-
-    func execute() async throws -> [Trip] {
-        try await repository.fetchAll()
-            .filter { $0.startDate > .now }
-            .sorted { $0.startDate < $1.startDate }
-    }
-}
-
-// Data layer
-struct RemoteTripRepository: TripRepository {
-    private let client: APIClient
-
-    func fetchAll() async throws -> [Trip] {
-        try await client.request(.get, "/trips")
-    }
-    // ...
-}
-
-// Presentation layer
-@MainActor
-@Observable
-final class UpcomingTripsViewModel {
-    private(set) var trips: [Trip] = []
-    private let useCase: FetchUpcomingTripsUseCase
-
-    init(useCase: FetchUpcomingTripsUseCase) {
-        self.useCase = useCase
-    }
+    init(client: TripClient) { self.client = client }
 
     func load() async {
-        trips = (try? await useCase.execute()) ?? []
+        do { trips = try await client.fetchTrips() }
+        catch { self.error = error }
+    }
+}
+
+struct TripList: View {
+    @State private var store: TripStore
+
+    init(client: TripClient) {
+        _store = State(initialValue: TripStore(client: client))
+    }
+
+    var body: some View {
+        List(store.trips) { Text($0.name) }
+            .task { await store.load() }
     }
 }
 ```
 
-**Use Clean Architecture when:** Strict separation is required (enterprise,
-regulated domains), the domain layer must be testable without any framework
-dependencies, or multiple presentation targets share the same business logic.
+Load [Architecture Pattern Recipes](references/architecture-patterns.md) for MVVM, MVI, TCA, Clean Architecture, Coordinator, and VIPER structure.
 
-## Coordinator Pattern
+## Escalation Signals
 
-Separates navigation logic from views. Especially useful in UIKit or hybrid
-apps with complex navigation flows.
+- Choose MVVM when substantial presentation transformation must be tested without rendering and the adapter has real behavior.
+- Choose MVI when transitions, invalid states, and effects need one auditable reducer-like path.
+- Choose TCA when feature composition, dependency overrides, cancellation, and deterministic effect tests recur across modules.
+- Choose Clean Architecture when independent domain rules and dependency direction matter across multiple delivery/data layers.
+- Add Coordinator for UIKit/hybrid route ownership, deep flow composition, or conditional navigation outside view controllers.
+- Keep VIPER for compatible legacy modules or deliberate migrations; do not start a new SwiftUI feature with it by habit.
 
-Keep Coordinators `@MainActor`, inject dependencies at coordinator creation,
-and pass user-selection callbacks from view models or controllers back to the
-coordinator. The coordinator owns push/modal decisions; feature models own
-business logic.
+Do not escalate merely because a view is long. First extract subviews, services, and focused observable models.
 
-In pure SwiftUI apps, `NavigationStack` with path-based routing often
-replaces the Coordinator pattern. Use Coordinators when you need UIKit
-integration or shared navigation logic across platforms.
+## Migration
 
-## VIPER
+Migrate one feature boundary at a time:
 
-VIPER splits a feature into **View**, **Interactor**, **Presenter**,
-**Entity**, and **Router** roles. Treat it as a maintenance pattern for apps
-that already have strict UIKit module boundaries rather than a default for new
-SwiftUI work.
+1. Freeze behavior with tests and a dependency/state inventory.
+2. Introduce the target boundary around existing operations.
+3. Move one state transition or dependency at a time without rewriting UI and persistence simultaneously.
+4. Compare behavior, navigation, cancellation, error, and persistence results after each slice.
+5. Remove the old path only after no callers or tests depend on it.
 
-**Use VIPER when:** An existing UIKit codebase already organizes screens as
-VIPER modules, teams need explicit handoff contracts between presentation,
-business logic, and routing, or a migration must preserve module boundaries
-while modernizing internals.
-
-**Avoid VIPER when:** A new SwiftUI feature can use MV, MVVM, TCA, or Clean
-Architecture with fewer files and clearer data flow.
-
-## Migration Between Patterns
-
-### ObservableObject → `@Observable`
-
-```swift
-// Before (iOS 16)
-class TripStore: ObservableObject {
-    @Published var trips: [Trip] = []
-}
-// View uses @ObservedObject or @StateObject
-
-// After (iOS 17+)
-@MainActor
-@Observable
-final class TripStore {
-    var trips: [Trip] = []
-}
-// View uses @State for owned; plain injection or @Bindable only when needed
-```
-
-Migration routing: keep Coordinators for UIKit or hybrid boundaries; pure
-SwiftUI flows usually own `NavigationStack`/path state. Route detailed route
-enums, `NavigationSplitView`, sheets, tabs, and deep links to
-`swiftui-navigation`, strict-concurrency diagnostics to `swift-concurrency`,
-and fixtures or parameterized tests to `swift-testing`. Migrate per feature module, not app-wide by default; keep each module internally consistent while allowing different modules to use different patterns during incremental adoption.
-
-### MVVM → MV (simplifying)
-
-If a view model only passes through model data without transforming it,
-remove the view model and let the view observe the model directly.
-
-### MV → MVVM (scaling up)
-
-Extract business logic and data transformation into a view model when:
-- The view's `body` contains conditional logic for data formatting
-- Multiple views need different projections of the same model
-- You need to test logic without instantiating views
-
-### Any → TCA
-
-TCA adoption is typically incremental: wrap one feature's state and actions
-in a `Reducer`, migrate its dependencies to `@Dependency`, and test.
+For `ObservableObject` to Observation, preserve the same owner and mutation isolation before replacing wrappers. For MVVM to MV, delete forwarding view-model members only after views bind to the same model/service behavior. For TCA adoption, wrap one feature's state/actions/effects and migrate dependencies incrementally.
 
 ## Common Mistakes
 
 | Mistake | Fix |
-|---------|-----|
-| Using `ObservableObject` in new iOS 17+ code | Use `@Observable`; isolate UI-observed app state to `@MainActor` for Swift 6 data-race safety |
-| View model that only forwards model properties | Remove the view model; use MV pattern |
-| Massive view model with navigation, networking, and formatting | Split into focused collaborators (coordinator, service, formatter) |
-| Choosing TCA for a two-screen app | Start with MV; adopt TCA when composition and testing demands justify it |
-| Protocol-heavy Clean Architecture for a simple feature | Match architecture complexity to feature complexity |
-| Coordinator pattern in pure SwiftUI without UIKit needs | Use `NavigationStack` path-based routing instead |
-| Starting new SwiftUI modules with VIPER | Reserve VIPER for legacy UIKit maintenance or strict module-boundary migrations |
-| Mixing architecture patterns inside one feature module | Keep one pattern inside each feature module; migrate different modules independently when needed |
+|---|---|
+| Pattern chosen by popularity | Tie it to an observed feature pressure. |
+| View model only forwards properties | Remove it and use MV. |
+| One object owns navigation, networking, formatting, persistence, and UI state | Split by responsibility and dependency direction. |
+| TCA or Clean Architecture applied to trivial screens | Start with MV and preserve an escalation seam. |
+| Coordinator used as a state architecture | Keep it focused on route/lifecycle ownership. |
+| Multiple patterns mixed inside one feature | Define one local state/effect model and migrate at feature boundaries. |
+| Big-bang migration | Move one tested vertical slice and rerun the same proof matrix. |
 
 ## Review Checklist
 
-- [ ] Architecture choice is justified by feature complexity and team needs
-- [ ] Architecture identifies the model/store owner; `@State`, plain injection, and `@Bindable` wiring hand off to `swiftui-patterns`
-- [ ] Dependencies are injected, not created internally (testability)
-- [ ] SwiftUI MV mechanics, `NavigationSplitView`, strict-concurrency diagnostics, fixtures, and parameterized tests hand off to sibling skills explicitly
-- [ ] State mutations happen in a clear, auditable location
-- [ ] View models (if present) are testable without views
-- [ ] No god objects — responsibilities are distributed appropriately
-- [ ] Pattern is consistent within each feature module, including during migrations
+- [ ] Choice is justified by concrete feature/team pressures
+- [ ] State owner, mutation path, dependencies, effects, and navigation owner are explicit
+- [ ] Dependencies are injected and replaceable in tests
+- [ ] Pattern cost is proportional to feature complexity
+- [ ] UI mechanics, navigation APIs, isolation, and test syntax route to sibling skills
+- [ ] Migration preserves behavior one vertical slice at a time
+- [ ] Failure, cancellation, navigation, and persistence behavior are verified after each slice
+- [ ] No forwarding-only layers or god objects remain
 
 ## References
 
-- Apple docs: [Observation](https://sosumi.ai/documentation/observation) | [Observable](https://sosumi.ai/documentation/observation/observable())
-- Apple docs: [Migrating from ObservableObject to Observable](https://sosumi.ai/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro)
-- Apple docs: [`State`](https://sosumi.ai/documentation/swiftui/state) | [`Bindable`](https://sosumi.ai/documentation/swiftui/bindable) | [`Environment`](https://sosumi.ai/documentation/swiftui/environment)
-- Apple docs: [`NavigationStack`](https://sosumi.ai/documentation/swiftui/navigationstack)
-- Apple docs: [Swift Testing](https://sosumi.ai/documentation/testing)
-- TCA docs: [ComposableArchitecture](https://sosumi.ai/external/https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture)
+- Detailed pattern structures: [references/architecture-patterns.md](references/architecture-patterns.md)
+- Apple: [Observation](https://sosumi.ai/documentation/observation) · [Migrating from ObservableObject to Observable](https://sosumi.ai/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro)
+- TCA: [ComposableArchitecture](https://sosumi.ai/external/https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture)

--- a/skills/swift-architecture/references/architecture-patterns.md
+++ b/skills/swift-architecture/references/architecture-patterns.md
@@ -1,0 +1,94 @@
+# Architecture Pattern Recipes
+
+Load this reference after the main skill selects a pattern. Keep feature behavior and dependency contracts stable while adopting these structures.
+
+## Contents
+
+- [MVVM](#mvvm)
+- [MVI](#mvi)
+- [TCA](#tca)
+- [Clean Architecture](#clean-architecture)
+- [Coordinator](#coordinator)
+- [VIPER](#viper)
+
+## MVVM
+
+Use a view model only when it owns presentation behavior rather than forwarding a model:
+
+```swift
+@MainActor @Observable
+final class CheckoutViewModel {
+    private let pricing: PricingService
+    var items: [LineItem] = []
+    var promoCode = ""
+
+    var total: Decimal { pricing.total(for: items, promoCode: promoCode) }
+
+    init(pricing: PricingService) { self.pricing = pricing }
+}
+```
+
+Inject the service, test transformations and error states directly, and keep view-only focus/layout state in the view.
+
+## MVI
+
+Define explicit state, user intents, and one transition/effect boundary:
+
+```swift
+struct SearchState: Equatable {
+    var query = ""
+    var results: [Result] = []
+    var isLoading = false
+}
+
+enum SearchIntent { case queryChanged(String), submitted, response([Result]) }
+
+@MainActor @Observable
+final class SearchStore {
+    private(set) var state = SearchState()
+    func send(_ intent: SearchIntent) { /* reduce and launch bounded effects */ }
+}
+```
+
+Test every state/intent pair, effect cancellation, and stale-response handling.
+
+## TCA
+
+Model each feature with state, actions, a reducer body, and injected dependencies. Compose child reducers at feature boundaries and test with `TestStore`. Keep navigation state in the feature only when the route belongs to that feature. Check the current Composable Architecture documentation before copying macro or testing syntax because package APIs evolve independently of Apple SDKs.
+
+## Clean Architecture
+
+Dependency direction points inward:
+
+```text
+UI / presenters -> use cases -> domain entities
+data adapters   -> repository protocols <- use cases
+```
+
+Keep domain types independent of SwiftUI, persistence, and networking. Introduce mapping only where it protects a real boundary; avoid one protocol per concrete type without a substitution need.
+
+## Coordinator
+
+Use a coordinator as the route and child-flow owner in UIKit or hybrid apps:
+
+```swift
+@MainActor
+protocol Coordinator: AnyObject {
+    var children: [Coordinator] { get set }
+    func start()
+}
+```
+
+Retain child coordinators for the flow lifetime, remove them on completion, and keep business state in the feature model rather than the coordinator.
+
+## VIPER
+
+Preserve existing responsibilities during maintenance:
+
+- View renders and forwards user events.
+- Interactor owns use-case logic.
+- Presenter maps results to view state.
+- Entity contains domain data.
+- Router owns UIKit navigation and module assembly.
+
+When migrating away, replace one module boundary at a time and keep adapters until upstream callers use the new feature interface.

--- a/skills/swift-charts/SKILL.md
+++ b/skills/swift-charts/SKILL.md
@@ -42,34 +42,22 @@ See [references/charts-patterns.md](references/charts-patterns.md) for extended 
 6. Set scale domains with `.chartXScale(domain:)` / `.chartYScale(domain:)`.
 7. Add selection, scrolling, or annotations as needed.
 8. For 1000+ 2D data points, use vectorized plots (`BarPlot`, `LinePlot`, etc.).
+9. Render representative empty, typical, dense, large-text, high-contrast, and VoiceOver states; exercise selection and scrolling when present.
+10. If an encoding, axis, selection, or accessibility check fails, restore the data fixture, fix one layer, and rerun the same matrix before adding decoration.
 
 ### 2. Review existing chart code
 
-Run through the Review Checklist at the end of this file.
+Identify the data semantics before judging mark choice. Then trace every value through mark, scale, axis, style, selection, and accessibility output; run the same validation matrix used for new charts.
 
 ## Chart Container
 
 ```swift
-// Data-driven init (single-series)
 Chart(sales) { item in
     BarMark(x: .value("Month", item.month), y: .value("Revenue", item.revenue))
 }
-
-// Content closure init (multi-series, mixed marks)
-Chart {
-    ForEach(seriesA) { item in
-        LineMark(x: .value("Date", item.date), y: .value("Value", item.value))
-            .foregroundStyle(.blue)
-    }
-    RuleMark(y: .value("Target", 500))
-        .foregroundStyle(.red)
-}
-
-// Custom ID key path
-Chart(data, id: \.category) { item in
-    BarMark(x: .value("Category", item.category), y: .value("Count", item.count))
-}
 ```
+
+Use the data-driven initializer for a single collection. Use the content closure for mixed marks or multiple series, and pass `id:` when elements are not `Identifiable`. Load [references/charts-patterns.md](references/charts-patterns.md) for complete mixed-series, theming, accessibility, and 3D recipes.
 
 ## Mark Types
 

--- a/skills/swift-codable/SKILL.md
+++ b/skills/swift-codable/SKILL.md
@@ -10,6 +10,7 @@ Encode and decode Swift types using `Codable` (`Encodable & Decodable`) with
 
 ## Contents
 
+- [Decode and Verify Workflow](#decode-and-verify-workflow)
 - [Basic Conformance](#basic-conformance)
 - [Custom CodingKeys](#custom-codingkeys)
 - [Custom Decoding and Encoding](#custom-decoding-and-encoding)
@@ -27,6 +28,16 @@ Encode and decode Swift types using `Codable` (`Encodable & Decodable`) with
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
 - [References](#references)
+
+## Decode and Verify Workflow
+
+1. Decode representative success, missing, null, malformed, acronym-key, and
+   date fixtures.
+2. On failure, inspect `DecodingError`, its `codingPath`, and the raw payload.
+3. Correct only the mismatched model, key, container, or strategy; do not hide
+   contract failures with lossy decoding.
+4. Rerun fixtures and encode/decode round trips where both directions are part
+   of the contract.
 
 ## Basic Conformance
 
@@ -137,36 +148,8 @@ Also use `nestedUnkeyedContainer(forKey:)` for nested arrays.
 
 ## Heterogeneous Arrays
 
-Decode arrays of mixed types using a discriminator field:
-
-```swift
-// JSON: [{"type":"text","content":"Hello"},{"type":"image","url":"pic.jpg"}]
-enum ContentBlock: Decodable {
-    case text(String)
-    case image(URL)
-
-    enum CodingKeys: String, CodingKey { case type, content, url }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        switch type {
-        case "text":
-            let content = try container.decode(String.self, forKey: .content)
-            self = .text(content)
-        case "image":
-            let url = try container.decode(URL.self, forKey: .url)
-            self = .image(url)
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type, in: container,
-                debugDescription: "Unknown type: \(type)")
-        }
-    }
-}
-
-let blocks = try JSONDecoder().decode([ContentBlock].self, from: jsonData)
-```
+Load [Advanced Codable Patterns](references/codable-advanced-patterns.md#heterogeneous-arrays)
+for discriminator-based mixed arrays.
 
 ## Date Decoding Strategies
 
@@ -222,102 +205,25 @@ declare explicit `CodingKeys`; the strategy will not synthesize those names.
 
 ## Lossy Array Decoding
 
-By default, one invalid element fails the entire array. Use a wrapper to skip
-invalid elements:
-
-```swift
-struct LossyArray<Element: Decodable>: Decodable {
-    let elements: [Element]
-
-    init(from decoder: Decoder) throws {
-        var container = try decoder.unkeyedContainer()
-        var elements: [Element] = []
-        while !container.isAtEnd {
-            if let element = try? container.decode(Element.self) {
-                elements.append(element)
-            } else {
-                _ = try? container.decode(AnyCodableValue.self) // advance past bad element
-            }
-        }
-        self.elements = elements
-    }
-}
-private struct AnyCodableValue: Decodable {}
-```
+Use lossy arrays only when partial success is part of the product contract; load
+[Lossy Arrays](references/codable-advanced-patterns.md#lossy-arrays).
 
 ## Single Value Containers
 
-Wrap primitives for type safety using `singleValueContainer()`:
-
-```swift
-struct UserID: Codable, Hashable {
-    let rawValue: String
-
-    init(_ rawValue: String) { self.rawValue = rawValue }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        rawValue = try container.decode(String.self)
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(rawValue)
-    }
-}
-// JSON: "usr_abc123" decodes directly to UserID
-```
+Use `singleValueContainer()` for type-safe primitive wrappers; see
+[Single-Value Wrappers](references/codable-advanced-patterns.md#single-value-wrappers).
 
 ## Default Values for Missing Keys
 
-Stored property defaults such as `var theme = "system"` do not make synthesized
-`Decodable` tolerate a missing nonoptional key; synthesis still fails unless the
-property is optional or decoded manually. Use `decodeIfPresent` with
-nil-coalescing when a missing or null key should fall back:
-
-```swift
-struct Settings: Decodable {
-    let theme: String
-    let fontSize: Int
-    let notificationsEnabled: Bool
-
-    enum CodingKeys: String, CodingKey {
-        case theme, fontSize = "font_size"
-        case notificationsEnabled = "notifications_enabled"
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        theme = try container.decodeIfPresent(String.self, forKey: .theme) ?? "system"
-        fontSize = try container.decodeIfPresent(Int.self, forKey: .fontSize) ?? 16
-        notificationsEnabled = try container.decodeIfPresent(
-            Bool.self, forKey: .notificationsEnabled) ?? true
-    }
-}
-```
+Stored defaults do not make synthesized decoding tolerate missing nonoptional
+keys. Load [Missing-Key Defaults](references/codable-advanced-patterns.md#missing-key-defaults)
+when the contract assigns explicit fallback behavior to missing or null values.
 
 ## Encoder and Decoder Configuration
 
-```swift
-let encoder = JSONEncoder()
-encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-
-let decoder = JSONDecoder()
-// Non-conforming floats (NaN, Infinity are not valid JSON)
-encoder.nonConformingFloatEncodingStrategy = .convertToString(
-    positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-decoder.nonConformingFloatDecodingStrategy = .convertFromString(
-    positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-```
-
-### PropertyListEncoder / PropertyListDecoder
-
-```swift
-let plistEncoder = PropertyListEncoder()
-plistEncoder.outputFormat = .xml  // or .binary
-let data = try plistEncoder.encode(settings)
-let decoded = try PropertyListDecoder().decode(Settings.self, from: data)
-```
+Keep matching strategies at the transport/file-format boundary. Load
+[Encoder Configuration](references/codable-advanced-patterns.md#encoder-configuration)
+for nonconforming floats and property-list guidance.
 
 ## Codable with URLSession
 
@@ -330,7 +236,7 @@ func fetchUser(id: Int) async throws -> User {
         throw APIError.invalidResponse
     }
     let decoder = JSONDecoder()
-    decoder.keyDecodingStrategy = .convertFromSnakeCase  // simple keys only; keep CodingKeys for URL/URI/ID
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
     decoder.dateDecodingStrategy = .iso8601
     return try decoder.decode(User.self, from: data)
 }
@@ -345,7 +251,7 @@ struct APIResponse<T: Decodable>: Decodable {
 
 func decodeUsersEnvelope(from data: Data) throws -> [User] {
     let decoder = JSONDecoder()
-    decoder.keyDecodingStrategy = .convertFromSnakeCase  // simple keys only; keep CodingKeys for URL/URI/ID
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
     decoder.dateDecodingStrategy = .iso8601
     return try decoder.decode(APIResponse<[User]>.self, from: data).data
 }
@@ -353,65 +259,15 @@ func decodeUsersEnvelope(from data: Data) throws -> [User] {
 
 ## Codable with SwiftData
 
-SwiftData persists compatible noncomputed stored properties declared on `@Model`
-types. Use `Codable` structs, enums, and other value types directly when that
-value is part of the durable model schema:
-
-```swift
-struct Address: Codable {
-    var street: String
-    var city: String
-    var zipCode: String
-}
-
-@Model class Contact {
-    var name: String
-    var address: Address?  // Codable value-type property stored by SwiftData
-    init(name: String, address: Address? = nil) {
-        self.name = name; self.address = address
-    }
-}
-```
-
-Do not recommend `@Attribute(.transformable)`, encoded `Data`, or encoded
-`String` as a fallback in this Codable skill. Keep schema data as typed
-SwiftData properties and defer unsupported persistence designs to the SwiftData skill.
+Keep schema values typed and route persistence design to `swiftdata`; see
+[Persistence Boundaries](references/codable-advanced-patterns.md#persistence-boundaries).
 
 ## Codable with UserDefaults
 
-`@AppStorage` is only for small UserDefaults-backed preferences. Store `Bool`,
-numeric, `String`, or a `RawRepresentable` type with a primitive raw value. For
-a small `Codable` preference payload, prefer `RawRepresentable` with JSON
-`String` raw storage so `@AppStorage` binds the typed preference directly:
-
-```swift
-struct UserPreferences: Codable {
-    var showOnboarding: Bool = true
-    var accentColor: String = "blue"
-}
-
-extension UserPreferences: RawRepresentable {
-    init?(rawValue: String) {
-        guard let data = rawValue.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode(Self.self, from: data)
-        else { return nil }
-        self = decoded
-    }
-    var rawValue: String {
-        guard let data = try? JSONEncoder().encode(self),
-              let string = String(data: data, encoding: .utf8)
-        else { return "{}" }
-        return string
-    }
-}
-
-struct SettingsView: View {
-    @AppStorage("userPrefs") private var prefs = UserPreferences()
-    var body: some View {
-        Toggle("Show Onboarding", isOn: $prefs.showOnboarding)
-    }
-}
-```
+Use primitives for small preferences. Load
+[Persistence Boundaries](references/codable-advanced-patterns.md#persistence-boundaries)
+for a small Codable `RawRepresentable`/`@AppStorage` handoff; use a real
+persistence layer for larger or durable data.
 
 ## Common Mistakes
 
@@ -427,8 +283,7 @@ let value = try container.decodeIfPresent(String.self, forKey: .bio) ?? ""
 ```swift
 // DON'T -- one bad element kills the whole decode
 let items = try container.decode([Item].self, forKey: .items)
-// DO -- use LossyArray or decode elements individually
-let items = try container.decode(LossyArray<Item>.self, forKey: .items).elements
+// DO -- decode elements individually only when partial success is allowed
 ```
 
 **3. Date strategy mismatch:**
@@ -484,6 +339,7 @@ decoder.keyDecodingStrategy = .convertFromSnakeCase
 
 ## References
 
+- [Advanced Codable patterns](references/codable-advanced-patterns.md) -- mixed arrays, lossy decoding, wrappers, defaults, configuration, and persistence boundaries
 - [Codable](https://sosumi.ai/documentation/swift/codable/) -- protocol combining Encodable and Decodable
 - [JSONDecoder](https://sosumi.ai/documentation/foundation/jsondecoder/) -- decodes JSON data into Codable types
 - [JSONEncoder](https://sosumi.ai/documentation/foundation/jsonencoder/) -- encodes Codable types as JSON data

--- a/skills/swift-codable/references/codable-advanced-patterns.md
+++ b/skills/swift-codable/references/codable-advanced-patterns.md
@@ -1,0 +1,109 @@
+# Advanced Codable Patterns
+
+Use these patterns after the model's core keys, nested containers, and decoding
+strategies are established.
+
+## Contents
+
+- [Heterogeneous Arrays](#heterogeneous-arrays)
+- [Lossy Arrays](#lossy-arrays)
+- [Single-Value Wrappers](#single-value-wrappers)
+- [Missing-Key Defaults](#missing-key-defaults)
+- [Encoder Configuration](#encoder-configuration)
+- [Persistence Boundaries](#persistence-boundaries)
+
+## Heterogeneous Arrays
+
+Decode a discriminator first, then decode only fields owned by that case:
+
+```swift
+enum ContentBlock: Decodable {
+    case text(String)
+    case image(URL)
+
+    enum CodingKeys: String, CodingKey { case type, content, url }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        switch try values.decode(String.self, forKey: .type) {
+        case "text": self = .text(try values.decode(String.self, forKey: .content))
+        case "image": self = .image(try values.decode(URL.self, forKey: .url))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type, in: values,
+                debugDescription: "Unknown content type"
+            )
+        }
+    }
+}
+```
+
+## Lossy Arrays
+
+Default array decoding fails when any element is invalid. Use lossy decoding
+only when the product contract permits partial data, and report skipped items.
+
+```swift
+struct LossyArray<Element: Decodable>: Decodable {
+    let elements: [Element]
+
+    init(from decoder: Decoder) throws {
+        var values = try decoder.unkeyedContainer()
+        var decoded: [Element] = []
+        while !values.isAtEnd {
+            if let value = try? values.decode(Element.self) {
+                decoded.append(value)
+            } else {
+                _ = try? values.decode(DiscardedValue.self)
+            }
+        }
+        elements = decoded
+    }
+}
+
+private struct DiscardedValue: Decodable {}
+```
+
+## Single-Value Wrappers
+
+```swift
+struct UserID: Codable, Hashable {
+    let rawValue: String
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var value = encoder.singleValueContainer()
+        try value.encode(rawValue)
+    }
+}
+```
+
+## Missing-Key Defaults
+
+A stored property default does not make synthesized decoding tolerate a missing
+nonoptional key. Decode manually when missing or null has an explicit fallback:
+
+```swift
+let values = try decoder.container(keyedBy: CodingKeys.self)
+theme = try values.decodeIfPresent(String.self, forKey: .theme) ?? "system"
+```
+
+Preserve the distinction between a missing key, explicit null, and malformed
+data when the API contract assigns them different meanings.
+
+## Encoder Configuration
+
+Configure matching date, data, float, and key strategies once per transport or
+file format. Use `PropertyListEncoder`/`PropertyListDecoder` for property lists;
+do not send plist configuration through JSON helpers.
+
+## Persistence Boundaries
+
+- SwiftData: persist supported Codable value types as typed model properties;
+  route schema and unsupported-storage decisions to `swiftdata`.
+- UserDefaults: store primitive preferences directly. For a small Codable
+  preference, a `RawRepresentable` wrapper with JSON-string storage can support
+  `@AppStorage`; route larger or durable data to a real persistence layer.

--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -436,13 +436,12 @@ escape, and no lock is held across `await`.
    use the `.task` view modifier.
 7. **Retain cycles in Tasks.** Use `[weak self]` when capturing `self` in
    long-lived stored tasks.
-8. **Semaphores in async context.** `DispatchSemaphore.wait()` in async code
-   will deadlock. Use structured concurrency instead.
+8. **Semaphores in async context.** `DispatchSemaphore.wait()` can block a cooperative executor thread and can deadlock when the signaller needs the blocked executor. Use an async primitive or structured concurrency.
 9. **Split isolation.** Mixing `@MainActor` and `nonisolated` properties in one
    type. Isolate the entire type consistently.
 10. **MainActor.run instead of static isolation.** Prefer `@MainActor func`
     over `await MainActor.run { }`.
-11. **Using GCD APIs.** Never use DispatchQueue, DispatchGroup, DispatchSemaphore, or any GCD API. Use async/await, actors, and TaskGroups instead. GCD has no data-race safety guarantees.
+11. **Using GCD for new async orchestration by default.** Prefer async/await, actors, and task groups. Keep dispatch queues where an API requires a queue, for custom executors, or during bounded legacy interop; document the isolation boundary instead of claiming GCD is universally forbidden.
 
 ## Review Checklist
 

--- a/skills/swift-formatstyle/SKILL.md
+++ b/skills/swift-formatstyle/SKILL.md
@@ -1,396 +1,134 @@
 ---
 name: swift-formatstyle
-description: "Format and parse values for display using the FormatStyle and ParseableFormatStyle protocols and Foundation's concrete styles. Use when formatting numbers (integers, floating-point, decimals), currencies, percentages, dates, date ranges, relative dates, durations (Duration.TimeFormatStyle, Duration.UnitsFormatStyle), measurements, person names (PersonNameComponents.FormatStyle), byte counts (ByteCountFormatStyle), lists (ListFormatStyle), and URLs (URL.FormatStyle). Also covers custom FormatStyle conformances, parse strategies, reusable formatter API design, and replacing legacy Formatter subclasses. FormatStyle is available iOS 15+; Duration and URL styles require iOS 16+."
+description: "Formats and parses locale-aware numbers, decimals, currencies, percentages, dates, durations, measurements, names, lists, byte counts, and URLs with Foundation FormatStyle and ParseableFormatStyle. Use when replacing legacy Formatter subclasses, designing reusable format APIs, using SwiftUI Text(_:format:), correcting availability, or testing user-facing formatted output across locales."
 ---
 
 # Swift FormatStyle
 
-Format values for human-readable display using the `FormatStyle` protocol
-and Foundation's concrete format styles. Replaces legacy `Formatter` subclasses
-with a type-safe, composable, cacheable API.
-
-Locale-aware display is an i18n concern even when the app is not adding new languages. When reviewing user-facing `FormatStyle` output or SwiftUI `Text(_:format:)`, always include an actionable preview/test step for the exact rendered UI in representative locales such as `en_US`, `de_DE`, `ar_SA`, and `ja_JP`; check separators, numbering systems, calendars, currency and unit conventions, text direction, and layout-sensitive output. Keep this skill focused on `FormatStyle`, `ParseableFormatStyle`, parsing, and reusable formatter API design; route broader localization work such as String Catalogs, bundles, plurals, localized copy, and RTL layout review to `ios-localization`. Do not use "not adding languages" as the reason to skip `ios-localization`; locale-sensitive formatting can be a localization review issue without translation work.
-
-Docs: [FormatStyle](https://sosumi.ai/documentation/foundation/formatstyle)
+Use Foundation's type-safe `FormatStyle` APIs for user-facing display and `ParseableFormatStyle` when the same convention must accept input. Route String Catalogs, plurals, localized copy, bundles, and RTL layout to `ios-localization`; formatting still requires locale review even when no text is translated.
 
 ## Contents
 
+- [Workflow](#workflow)
 - [Quick Reference](#quick-reference)
-- [Numbers](#numbers)
-- [Decimals](#decimals)
-- [Currency](#currency)
-- [Percentages](#percentages)
-- [Dates](#dates)
-- [Durations](#durations)
-- [Measurements](#measurements)
-- [Person Names](#person-names)
-- [Lists](#lists)
-- [Byte Counts](#byte-counts)
-- [URLs](#urls)
+- [Selection and Availability](#selection-and-availability)
+- [Parsing](#parsing)
 - [SwiftUI Integration](#swiftui-integration)
 - [Custom FormatStyle](#custom-formatstyle)
 - [Common Mistakes](#common-mistakes)
 - [Review Checklist](#review-checklist)
+- [References](#references)
+
+## Workflow
+
+1. Identify the value's semantic type and whether output is display-only or must round-trip through parsing.
+2. Select the narrowest built-in style and keep the user's current locale unless a wire format explicitly requires another locale.
+3. Render the exact UI with representative locales such as `en_US`, `de_DE`, `ar_SA`, and `ja_JP`.
+4. Check separators, numbering systems, calendars, currency and unit conventions, text direction, and layout.
+5. If output or parsing fails, fix the style or surrounding copy, restore the input fixture, and rerun the same locale matrix.
+
+Load [FormatStyle Recipes](references/formatstyle-recipes.md) when implementation needs concrete modifiers, date intervals, relative dates, duration patterns, measurements, names, lists, byte counts, or URL component controls.
 
 ## Quick Reference
 
-| Type | Style Access | Example |
-|------|-------------|---------|
-| `Int`, `Double` | `.number` | `42.formatted(.number.precision(.fractionLength(2)))` → `"42.00"` |
-| `Decimal` | `.number`, `.percent`, `.currency(code:)` | `Decimal(string: "0.1")!.formatted(.percent)` -> `"10%"` |
-| Currency | `.currency(code:)` | `29.99.formatted(.currency(code: "USD"))` -> `"$29.99"` |
-| Percent | `.percent` | `0.85.formatted(.percent)` → `"85%"` |
-| `Date` | `.dateTime` | `Date.now.formatted(.dateTime.month().day().year())` |
-| Date range | `.interval` | `(date1..<date2).formatted(.interval)` |
-| Relative date | `.relative(presentation:unitsStyle:)` | `date.formatted(.relative(presentation: .named))` → `"yesterday"` |
-| `Duration` | `.time(pattern:)` | `Duration.seconds(3661).formatted(.time(pattern: .hourMinuteSecond))` → `"1:01:01"` |
-| `Duration` | `.units(allowed:width:)` | `Duration.seconds(90).formatted(.units(allowed: [.minutes, .seconds]))` → `"1 min, 30 sec"` |
-| `Measurement` | `.measurement(width:)` | `Measurement(value: 72, unit: UnitTemperature.fahrenheit).formatted(.measurement(width: .abbreviated))` |
-| `PersonNameComponents` | `.name(style:)` | `name.formatted(.name(style: .short))` → `"Tom"` |
-| `[String]` | `.list(type:width:)` | `["A","B","C"].formatted(.list(type: .and))` → `"A, B, and C"` |
-| Byte count | `.byteCount(style:)` | `Int64(1_048_576).formatted(.byteCount(style: .memory))` → `"1 MB"` |
-| `URL` | `.url` | `url.formatted(.url.scheme(.never).host().path())` |
+| Value | Default style | Important constraint |
+|---|---|---|
+| `Int`, `Double` | `.number` | Configure precision, rounding, grouping, notation, or sign only as required. |
+| `Decimal` | `.number`, `.percent`, `.currency(code:)` | Prefer for exact decimal display and parsing. |
+| Currency | `.currency(code:)` | Pass an ISO 4217 code; never hardcode a symbol. |
+| Percent | `.percent` | Confirm whether the input is a fraction (`0.85`) or whole percent (`85`). |
+| `Date` | `.dateTime`, `.relative`, `.interval` | Relative output should usually stand alone, not be embedded in a sentence. |
+| `Duration` | `.time(pattern:)`, `.units(allowed:width:)` | Requires iOS 16+; choose compact clock output versus labeled units. |
+| `Measurement` | `.measurement(width:usage:)` | `usage:` controls locale-aware conversion policy. |
+| `PersonNameComponents` | `.name(style:)` | Do not manually concatenate name parts. |
+| Collections | `.list(type:width:)` | Let locale rules choose separators and conjunctions. |
+| Byte count | `.byteCount(style:)` | Choose file, memory, decimal, or binary semantics deliberately. |
+| `URL` | `.url` | Requires iOS 16+; query, port, and fragment are opt-in display components. |
 
-## Numbers
+## Selection and Availability
 
-```swift
-// Default locale-aware formatting
-let n = 1234567.formatted()  // "1,234,567" (en_US)
+- Prefer `FormatStyle` over legacy `NumberFormatter`, `DateFormatter`, `DateComponentsFormatter`, and manual interpolation for new iOS 15+ code.
+- `Duration` format styles and `URL.FormatStyle` require iOS 16+.
+- `Date.AnchoredRelativeFormatStyle` requires iOS 18+ and formats relative to a fixed anchor rather than the current moment.
+- Omit `.locale(...)` for normal UI so the style inherits the user's locale. Use a fixed locale only for an explicit protocol or test fixture.
+- Treat relative date output as standalone text unless the entire sentence is localized around it.
 
-// Precision
-1234.5.formatted(.number.precision(.fractionLength(0...2)))  // "1,234.5"
-1234.5.formatted(.number.precision(.significantDigits(3)))    // "1,230"
+Docs: [FormatStyle](https://sosumi.ai/documentation/foundation/formatstyle)
 
-// Rounding
-1234.formatted(.number.rounded(rule: .down, increment: 100)) // "1,200"
+## Parsing
 
-// Grouping
-1234567.formatted(.number.grouping(.never))                   // "1234567"
-
-// Notation
-1_200_000.formatted(.number.notation(.compactName))           // "1.2M"
-42.formatted(.number.notation(.scientific))                    // "4.2E1"
-
-// Sign display
-(-42).formatted(.number.sign(strategy: .always()))            // "+42" / "-42"
-
-// Locale override
-42.formatted(.number.locale(Locale(identifier: "de_DE")))     // "42"
-```
-
-Docs: [IntegerFormatStyle](https://sosumi.ai/documentation/foundation/integerformatstyle),
-[FloatingPointFormatStyle](https://sosumi.ai/documentation/foundation/floatingpointformatstyle)
-
-## Decimals
-
-Use `Decimal.FormatStyle` for exact decimal values, especially money-like values
-that should not pass through binary floating-point.
+Use the matching parseable style when users edit or import formatted values:
 
 ```swift
-let amount = Decimal(string: "12345.67")!
+let style = Decimal.FormatStyle.Currency(code: "USD")
+    .locale(Locale(identifier: "en_US"))
 
-amount.formatted(.number)                         // "12,345.67" (en_US)
-amount.formatted(.number.grouping(.never))        // "12345.67"
-Decimal(string: "0.1")!.formatted(.percent)       // "10%"
-amount.formatted(.currency(code: "USD"))          // "$12,345.67"
-
-// Parsing with the same style
-let price = try? Decimal("$3,500.63", format: .currency(code: "USD"))
+let value = try Decimal("$3,500.63", format: style)
+let display = value.formatted(style)
 ```
 
-Docs: [Decimal.FormatStyle](https://sosumi.ai/documentation/foundation/decimal/formatstyle)
-
-## Currency
-
-```swift
-29.99.formatted(.currency(code: "USD"))   // "$29.99"
-29.99.formatted(.currency(code: "EUR"))   // "€29.99"
-29.99.formatted(.currency(code: "JPY"))   // "¥30"
-
-// Customize precision
-let style = FloatingPointFormatStyle<Double>.Currency(code: "USD")
-    .precision(.fractionLength(0))
-1234.56.formatted(style)  // "$1,235"
-```
-
-## Percentages
-
-```swift
-0.85.formatted(.percent)                                      // "85%"
-0.8567.formatted(.percent.precision(.fractionLength(1)))       // "85.7%"
-42.formatted(.percent)                                         // "42%"  (integer)
-```
-
-## Dates
-
-```swift
-let now = Date.now
-
-// Components
-now.formatted(.dateTime.year().month().day())           // "Apr 22, 2026"
-now.formatted(.dateTime.hour().minute())                // "4:30 PM"
-now.formatted(.dateTime.weekday(.wide).month(.wide).day()) // "Wednesday, April 22"
-
-// Predefined styles
-now.formatted(date: .long, time: .shortened)            // "April 22, 2026 at 4:30 PM"
-now.formatted(date: .abbreviated, time: .omitted)       // "Apr 22, 2026"
-
-// ISO 8601
-now.formatted(.iso8601)                                 // "2026-04-22T16:30:00Z"
-
-// Relative
-let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: .now)!
-yesterday.formatted(.relative(presentation: .named))    // "yesterday"
-yesterday.formatted(.relative(presentation: .numeric))  // "1 day ago"
-
-// Treat relative strings as standalone text; embedding them inside another
-// sentence can be grammatically wrong in some locales. Recommend previewing or
-// testing the exact screen in representative locales before approving copy.
-Text(yesterday, format: .relative(presentation: .named))
-
-// Interval
-(date1..<date2).formatted(.interval.month().day().hour().minute())
-
-// Components (countdown-style)
-(date1..<date2).formatted(.components(style: .wide, fields: [.day, .hour]))
-// "2 days, 5 hours"
-```
-
-Docs: [Date.FormatStyle](https://sosumi.ai/documentation/foundation/date/formatstyle),
-[Date.RelativeFormatStyle](https://sosumi.ai/documentation/foundation/date/relativeformatstyle),
-[Date.IntervalFormatStyle](https://sosumi.ai/documentation/foundation/date/intervalformatstyle)
-
-### Anchored Relative Dates (iOS 18+)
-
-`Date.AnchoredRelativeFormatStyle` formats relative to a fixed anchor date
-rather than the current moment. It requires iOS 18+.
-
-Docs: [Date.AnchoredRelativeFormatStyle](https://sosumi.ai/documentation/foundation/date/anchoredrelativeformatstyle)
-
-## Durations
-
-`Duration` (iOS 16+) has two format styles:
-
-Docs: [Duration.TimeFormatStyle](https://sosumi.ai/documentation/swift/duration/timeformatstyle),
-[Duration.UnitsFormatStyle](https://sosumi.ai/documentation/swift/duration/unitsformatstyle)
-
-### TimeFormatStyle — compact separator-based
-
-```swift
-let d = Duration.seconds(3661)
-
-d.formatted(.time(pattern: .hourMinuteSecond))       // "1:01:01"
-d.formatted(.time(pattern: .hourMinute))             // "1:01"
-d.formatted(.time(pattern: .minuteSecond))           // "61:01"
-
-// Fractional seconds
-Duration.seconds(3.75).formatted(
-    .time(pattern: .minuteSecond(padMinuteToLength: 2, fractionalSecondsLength: 2))
-)  // "00:03.75"
-```
-
-### UnitsFormatStyle — labeled units
-
-```swift
-Duration.seconds(3661).formatted(
-    .units(allowed: [.hours, .minutes, .seconds], width: .abbreviated)
-)  // "1 hr, 1 min, 1 sec"
-
-Duration.seconds(90).formatted(
-    .units(allowed: [.minutes, .seconds], width: .wide)
-)  // "1 minute, 30 seconds"
-
-Duration.seconds(90).formatted(
-    .units(allowed: [.minutes, .seconds], width: .narrow)
-)  // "1m 30s"
-
-// Limit unit count
-Duration.seconds(3661).formatted(
-    .units(allowed: [.hours, .minutes, .seconds], width: .abbreviated, maximumUnitCount: 2)
-)  // "1 hr, 1 min"
-```
-
-## Measurements
-
-```swift
-let temp = Measurement(value: 72, unit: UnitTemperature.fahrenheit)
-temp.formatted(.measurement(width: .wide))        // "72 degrees Fahrenheit"
-temp.formatted(.measurement(width: .abbreviated))  // "72°F"
-temp.formatted(.measurement(width: .narrow))       // "72°"
-
-let dist = Measurement(value: 5, unit: UnitLength.kilometers)
-dist.formatted(.measurement(width: .abbreviated, usage: .road))  // "3.1 mi" (en_US)
-```
-
-Docs: [Measurement.FormatStyle](https://sosumi.ai/documentation/foundation/measurement/formatstyle)
-
-## Person Names
-
-```swift
-var name = PersonNameComponents()
-name.givenName = "Thomas"
-name.familyName = "Clark"
-name.middleName = "Louis"
-name.namePrefix = "Dr."
-name.nickname = "Tom"
-name.nameSuffix = "Esq."
-
-name.formatted(.name(style: .long))        // "Dr. Thomas Louis Clark Esq."
-name.formatted(.name(style: .medium))      // "Thomas Clark"
-name.formatted(.name(style: .short))       // "Tom"
-name.formatted(.name(style: .abbreviated)) // "TC"
-```
-
-Style resolution follows priority: script → user preferences → locale → developer setting.
-
-Docs: [PersonNameComponents.FormatStyle](https://sosumi.ai/documentation/foundation/personnamecomponents/formatstyle)
-
-## Lists
-
-```swift
-["Alice", "Bob", "Charlie"].formatted(.list(type: .and))
-// "Alice, Bob, and Charlie"
-
-["Alice", "Bob", "Charlie"].formatted(.list(type: .or))
-// "Alice, Bob, or Charlie"
-
-// With member formatting
-[1, 2, 3].formatted(.list(memberStyle: .number, type: .and))
-// "1, 2, and 3"
-
-// Narrow width
-["A", "B", "C"].formatted(.list(type: .and, width: .narrow))
-// "A, B, C"
-```
-
-Docs: [ListFormatStyle](https://sosumi.ai/documentation/foundation/listformatstyle)
-
-## Byte Counts
-
-```swift
-Int64(1_048_576).formatted(.byteCount(style: .memory))   // "1 MB"
-Int64(1_048_576).formatted(.byteCount(style: .file))      // "1 MB"
-Int64(1_048_576).formatted(.byteCount(style: .binary))    // "1 MiB"
-```
-
-Docs: [ByteCountFormatStyle](https://sosumi.ai/documentation/foundation/bytecountformatstyle)
-
-## URLs
-
-`URL.FormatStyle` requires iOS 16+. The default style includes scheme, host,
-and path. Treat port, query, and fragment as opt-in display components; add
-`.port(.always)`, `.query(.always)`, or `.fragment(.always)` only when those
-components should be visible.
-
-```swift
-let url = URL(string: "https://www.example.com:8080/path?q=1#section")!
-url.formatted()
-// "https://www.example.com/path"
-
-url.formatted(.url.scheme(.never).host().path())
-// "www.example.com/path"
-
-url.formatted(.url.scheme(.never).host().path().query(.always))
-// "www.example.com/path?q=1"
-
-url.formatted(.url.scheme(.never).host().path().fragment(.always))
-// "www.example.com/path#section"
-```
-
-When auditing URL component choices, recommend previewing or testing the exact
-rendered URL text in representative locales, especially when choosing whether
-to show or hide scheme, path, query, port, or fragment.
-
-Docs: [URL.FormatStyle](https://sosumi.ai/documentation/foundation/url/formatstyle)
+The fixed locale above is appropriate only because the input contract is explicitly `en_US`. For normal UI input, use the user's locale and test round trips with representative decimal separators, currency placement, calendars, and numbering systems.
 
 ## SwiftUI Integration
 
-`Text` accepts a `format:` parameter, keeping formatting out of the view model.
+Prefer `Text(_:format:)` so SwiftUI owns the formatted value:
 
 ```swift
-// Inline format style
-Text(price, format: .currency(code: "USD"))
+Text(price, format: .currency(code: currencyCode))
 Text(date, format: .dateTime.month().day().year())
 Text(duration, format: .units(allowed: [.minutes, .seconds]))
-
-// Timer-style (live updating)
-Text(.now, style: .timer)
-Text(.now, style: .relative)
-Text(timerInterval: start...end)
 ```
 
-**Prefer `Text(_:format:)` over string interpolation** — it allows SwiftUI to
-re-render only the formatted value and supports accessibility scaling.
-For every SwiftUI formatted `Text` review, include a representative-locale
-preview, UI test, or snapshot test recommendation for the exact screen.
+For every user-facing formatted `Text`, preview or test the exact screen across the locale matrix. Use `Text(.now, style: .timer)`, `Text(.now, style: .relative)`, or `Text(timerInterval:)` for live-updating time displays rather than manually scheduling string refreshes.
 
 ## Custom FormatStyle
 
-Conform to `FormatStyle` for domain-specific formatting. Conform to
-`ParseableFormatStyle` if you also need parsing. `FormatStyle` refines
-`Decodable`, `Encodable`, and `Hashable`, and Foundation caches identical
-customized style instances, so reusable value-style formatters are cheap.
+Create a custom style only when built-in composition cannot express the domain convention. `FormatStyle` refines `Codable` and `Hashable`; keep styles as reusable values and add `ParseableFormatStyle` only when input must round-trip.
 
 ```swift
 struct AbbreviatedCountStyle: FormatStyle {
     func format(_ value: Int) -> String {
         switch value {
-        case ..<1_000:
-            return "\(value)"
-        case 1_000..<1_000_000:
-            return String(format: "%.1fK", Double(value) / 1_000)
-        default:
-            return String(format: "%.1fM", Double(value) / 1_000_000)
+        case ..<1_000: "\(value)"
+        case 1_000..<1_000_000: String(format: "%.1fK", Double(value) / 1_000)
+        default: String(format: "%.1fM", Double(value) / 1_000_000)
         }
     }
 }
 
 extension FormatStyle where Self == AbbreviatedCountStyle {
-    static var abbreviatedCount: AbbreviatedCountStyle { .init() }
+    static var abbreviatedCount: Self { .init() }
 }
-
-// Usage
-let followers = 12_500
-Text(followers, format: .abbreviatedCount)  // "12.5K"
 ```
 
-For parseable custom styles, pair formatting with a parse strategy and use the
-same conventions in both directions. Prefer this only when users edit or import
-the formatted value; display-only styles should stay as `FormatStyle`.
-
-Docs: [ParseableFormatStyle](https://sosumi.ai/documentation/foundation/parseableformatstyle)
+Custom styles still need locale and accessibility review; a compact English suffix may not be suitable for every locale.
 
 ## Common Mistakes
 
 | Mistake | Fix |
-|---------|-----|
-| Using legacy `NumberFormatter` / `DateFormatter` in new code | Use `FormatStyle` (iOS 15+). Foundation caches format style instances automatically. |
-| String interpolation for formatted numbers in `Text` | Use `Text(value, format:)` for locale correctness and accessibility |
-| Hardcoding locale in format styles | Omit `.locale()` to inherit the user's current locale by default |
-| Assuming `URL.formatted()` preserves query strings, ports, or fragments | Default URL formatting includes scheme, host, and path only; opt in with `.query(.always)`, `.port(.always)`, or `.fragment(.always)` |
-| Embedding relative date output inside larger sentences | Use `Date.RelativeFormatStyle` output as standalone text; localized grammar may not fit interpolation |
-| Forgetting availability checks | `URL.FormatStyle` and `Duration` format styles require iOS 16+; `Date.AnchoredRelativeFormatStyle` requires iOS 18+ |
-| Using `.time(pattern:)` for labeled duration display | Use `.units(allowed:width:)` for "1 hr, 30 min" style output |
-| Creating `Formatter` instances in `body` or tight loops | FormatStyle instances are value types cached by Foundation; safe to create inline |
-| Formatting `Duration` with `DateComponentsFormatter` | Use `Duration.TimeFormatStyle` or `Duration.UnitsFormatStyle` directly |
-| Ignoring `usage:` parameter for measurements | Specify `.road`, `.asProvided`, etc. for locale-aware unit conversion |
-| Using binary floating-point for exact decimal display/parsing | Use `Decimal.FormatStyle` and matching parse strategies for exact decimal values |
+|---|---|
+| Manual formatting or legacy formatter allocation in view code | Use the matching `FormatStyle` and `Text(_:format:)`. |
+| Hardcoded currency symbol or locale | Pass an ISO currency code and inherit the user locale unless the contract says otherwise. |
+| Binary floating-point for exact decimal input | Use `Decimal.FormatStyle` and its matching parse strategy. |
+| Assuming `URL.formatted()` preserves every component | Opt in to `.port(.always)`, `.query(.always)`, or `.fragment(.always)` only when those components should display. |
+| Relative date output embedded in a larger sentence | Keep it standalone or localize the complete sentence. |
+| Clock-style duration used for prose | Use `.units(allowed:width:)` for labeled output. |
+| Measurement conversion left implicit | Select a `usage:` appropriate to the UI. |
+| One-locale spot check | Run the same exact-screen fixture across representative locales and fix/rerun failures. |
 
 ## Review Checklist
 
-- [ ] `FormatStyle` used instead of legacy `Formatter` subclasses for iOS 15+ targets
-- [ ] `URL.FormatStyle` and `Duration` styles gated to iOS 16+; anchored relative dates gated to iOS 18+
-- [ ] `Text(_:format:)` used instead of pre-formatting strings for SwiftUI text
-- [ ] Every user-facing formatted value or SwiftUI formatted `Text` includes an explicit representative-locale preview/test recommendation
-- [ ] No hardcoded locale unless explicitly needed (e.g., server communication)
-- [ ] Decimal values use `Decimal.FormatStyle` when exact decimal formatting or parsing matters
-- [ ] URL formatting explicitly includes query, port, or fragment only when those components should display, with representative-locale preview for user-facing URL text
-- [ ] Relative date strings are used standalone, not interpolated into larger localized sentences, and previewed in representative locales
-- [ ] Duration formatting uses `Duration.TimeFormatStyle` or `Duration.UnitsFormatStyle`
-- [ ] Currency codes are ISO 4217 strings, not hardcoded symbols
-- [ ] Measurement formatting includes `usage:` for user-facing display
-- [ ] Custom FormatStyle types conform to `Codable` + `Hashable` for caching
+- [ ] Semantic value type and display-versus-parse requirement identified
+- [ ] Built-in `FormatStyle` used where it can express the convention
+- [ ] Availability gated beside iOS 16+ and iOS 18+ APIs
+- [ ] Currency uses an ISO 4217 code; exact decimal values use `Decimal`
+- [ ] User locale inherited unless a protocol explicitly fixes it
+- [ ] Relative date text stands alone or the full sentence is localized
+- [ ] URL components and measurement `usage:` are deliberate
+- [ ] SwiftUI uses `Text(_:format:)` for formatted values
+- [ ] Exact rendered UI and parse round trips pass the representative-locale matrix
 
 ## References
 
-- Apple docs: [FormatStyle](https://sosumi.ai/documentation/foundation/formatstyle) | [ParseableFormatStyle](https://sosumi.ai/documentation/foundation/parseableformatstyle) | [Decimal.FormatStyle](https://sosumi.ai/documentation/foundation/decimal/formatstyle) | [Date.FormatStyle](https://sosumi.ai/documentation/foundation/date/formatstyle) | [Date.RelativeFormatStyle](https://sosumi.ai/documentation/foundation/date/relativeformatstyle) | [Duration.TimeFormatStyle](https://sosumi.ai/documentation/swift/duration/timeformatstyle) | [URL.FormatStyle](https://sosumi.ai/documentation/foundation/url/formatstyle)
+- Detailed recipes and modifiers: [references/formatstyle-recipes.md](references/formatstyle-recipes.md)
+- Apple docs: [FormatStyle](https://sosumi.ai/documentation/foundation/formatstyle) · [ParseableFormatStyle](https://sosumi.ai/documentation/foundation/parseableformatstyle) · [Date.FormatStyle](https://sosumi.ai/documentation/foundation/date/formatstyle) · [Duration.TimeFormatStyle](https://sosumi.ai/documentation/swift/duration/timeformatstyle) · [URL.FormatStyle](https://sosumi.ai/documentation/foundation/url/formatstyle)

--- a/skills/swift-formatstyle/references/formatstyle-recipes.md
+++ b/skills/swift-formatstyle/references/formatstyle-recipes.md
@@ -1,0 +1,116 @@
+# FormatStyle Recipes
+
+Load this reference when concrete formatting modifiers or less common built-in styles are needed.
+
+## Contents
+
+- [Numbers and Decimals](#numbers-and-decimals)
+- [Currency and Percent](#currency-and-percent)
+- [Dates](#dates)
+- [Durations](#durations)
+- [Measurements and Names](#measurements-and-names)
+- [Lists and Byte Counts](#lists-and-byte-counts)
+- [URLs](#urls)
+
+## Numbers and Decimals
+
+```swift
+1234.5.formatted(.number.precision(.fractionLength(0...2)))
+1234.5.formatted(.number.precision(.significantDigits(3)))
+1234.formatted(.number.rounded(rule: .down, increment: 100))
+1_200_000.formatted(.number.notation(.compactName))
+42.formatted(.number.notation(.scientific))
+(-42).formatted(.number.sign(strategy: .always()))
+
+let amount = Decimal(string: "12345.67")!
+amount.formatted(.number)
+amount.formatted(.number.grouping(.never))
+let parsed = try? Decimal("3.500,63", format: .number.locale(.init(identifier: "de_DE")))
+```
+
+Docs: [IntegerFormatStyle](https://sosumi.ai/documentation/foundation/integerformatstyle) · [Decimal.FormatStyle](https://sosumi.ai/documentation/foundation/decimal/formatstyle)
+
+## Currency and Percent
+
+```swift
+29.99.formatted(.currency(code: "USD"))
+Decimal(string: "12345.67")!.formatted(.currency(code: "EUR"))
+0.8567.formatted(.percent.precision(.fractionLength(1)))
+```
+
+Confirm the percent input contract: floating-point `.percent` commonly treats `0.85` as 85%, while integer `42.formatted(.percent)` displays 42%.
+
+## Dates
+
+```swift
+let now = Date.now
+now.formatted(.dateTime.weekday(.wide).month(.wide).day())
+now.formatted(date: .long, time: .shortened)
+now.formatted(.iso8601)
+
+let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+yesterday.formatted(.relative(presentation: .named))
+(start..<end).formatted(.interval.month().day().hour().minute())
+(start..<end).formatted(.components(style: .wide, fields: [.day, .hour]))
+```
+
+Use `Date.AnchoredRelativeFormatStyle` on iOS 18+ when the anchor must be fixed rather than `Date.now`. Preview relative output as standalone text; embedding it can produce ungrammatical localized sentences.
+
+Docs: [Date.FormatStyle](https://sosumi.ai/documentation/foundation/date/formatstyle) · [Date.RelativeFormatStyle](https://sosumi.ai/documentation/foundation/date/relativeformatstyle) · [Date.IntervalFormatStyle](https://sosumi.ai/documentation/foundation/date/intervalformatstyle)
+
+## Durations
+
+```swift
+let duration = Duration.seconds(3661)
+
+duration.formatted(.time(pattern: .hourMinuteSecond))
+Duration.seconds(3.75).formatted(
+    .time(pattern: .minuteSecond(padMinuteToLength: 2, fractionalSecondsLength: 2))
+)
+duration.formatted(
+    .units(allowed: [.hours, .minutes, .seconds], width: .abbreviated,
+           maximumUnitCount: 2)
+)
+```
+
+Use `.time(pattern:)` for separator-based clock output and `.units(allowed:width:)` for labeled prose. Both require iOS 16+.
+
+## Measurements and Names
+
+```swift
+let temperature = Measurement(value: 72, unit: UnitTemperature.fahrenheit)
+temperature.formatted(.measurement(width: .abbreviated))
+
+let distance = Measurement(value: 5, unit: UnitLength.kilometers)
+distance.formatted(.measurement(width: .abbreviated, usage: .road))
+
+var name = PersonNameComponents()
+name.givenName = "Thomas"
+name.familyName = "Clark"
+name.nickname = "Tom"
+name.formatted(.name(style: .short))
+```
+
+Do not manually concatenate person names. Style resolution accounts for script, user preferences, locale, and requested style.
+
+## Lists and Byte Counts
+
+```swift
+["Alice", "Bob", "Charlie"].formatted(.list(type: .and))
+[1, 2, 3].formatted(.list(memberStyle: .number, type: .or))
+Int64(1_048_576).formatted(.byteCount(style: .memory))
+Int64(1_048_576).formatted(.byteCount(style: .binary))
+```
+
+## URLs
+
+`URL.FormatStyle` requires iOS 16+. Scheme, host, and path are the normal display surface; port, query, and fragment are opt-in.
+
+```swift
+let url = URL(string: "https://www.example.com:8080/path?q=1#section")!
+url.formatted(.url.scheme(.never).host().path())
+url.formatted(.url.scheme(.never).host().path().port(.always).query(.always))
+url.formatted(.url.scheme(.never).host().path().fragment(.always))
+```
+
+Treat this as display formatting, not URL sanitization or a security boundary.

--- a/skills/swift-language/SKILL.md
+++ b/skills/swift-language/SKILL.md
@@ -5,8 +5,10 @@ description: "Apply modern Swift language patterns and idioms for non-concurrenc
 
 # Swift Language Patterns
 
-Core Swift language features and modern syntax patterns targeting Swift 6.3. For helper modernization, preserve behavior and evaluation order while preferring `guard` preconditions, typed throws for one local error enum, `count(where:)`, and direct if/switch expression returns. Covers language constructs, type system features, basic Codable,
-string and collection APIs, basic formatting, C interop (`@c`), module disambiguation (`ModuleName::symbol`), and performance attributes (`@specialized`, `@inline(always)`). For `@c` corrections, call `UnsafeBufferPointer` a Swift struct/value wrapper and enumerate invalid Swift-only signature types: `String`, `Array`, closures, generic placeholders. Route deeper Codable/API decoding to `swift-codable`, detailed formatting/localization to `swift-formatstyle`, API naming to `swift-api-design-guidelines`, concurrency to `swift-concurrency`, and SwiftUI state/view work to `swiftui-patterns`.
+Apply current Swift language syntax without changing behavior or evaluation order.
+Route deep decoding to `swift-codable`, formatting to `swift-formatstyle`, naming
+to `swift-api-design-guidelines`, concurrency to `swift-concurrency`, and SwiftUI
+state/view work to `swiftui-patterns`.
 
 ## Contents
 
@@ -27,6 +29,10 @@ string and collection APIs, basic formatting, C interop (`@c`), module disambigu
 - [References](#references)
 
 ## If/Switch Expressions
+
+For modernization, pin current behavior and evaluation order, make one semantic
+rewrite, compile the affected module, and run focused fixtures/tests. Fix any
+change before continuing; repeat until behavior is preserved.
 
 Swift 5.9+ allows `if` and `switch` as expressions that return values. Use them
 to assign, return, or initialize directly.
@@ -301,81 +307,10 @@ let priceRegex = Regex {
 
 ## Codable Best Practices
 
-### Custom CodingKeys
-
-Rename keys without writing a custom decoder:
-
-```swift
-struct User: Codable {
-    let id: Int
-    let displayName: String
-    let avatarURL: URL
-
-    enum CodingKeys: String, CodingKey {
-        case id
-        case displayName = "display_name"
-        case avatarURL = "avatar_url"
-    }
-}
-```
-
-### Custom Decoding
-
-Handle mismatched types, defaults, and transformations:
-
-```swift
-struct Item: Decodable {
-    let name: String
-    let quantity: Int
-    let isActive: Bool
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        name = try container.decode(String.self, forKey: .name)
-        quantity = try container.decodeIfPresent(Int.self, forKey: .quantity) ?? 0
-        if let boolValue = try? container.decode(Bool.self, forKey: .isActive) {
-            isActive = boolValue
-        } else {
-            isActive = (try container.decode(String.self, forKey: .isActive)).lowercased() == "true"
-        }
-    }
-    enum CodingKeys: String, CodingKey { case name, quantity; case isActive = "is_active" }
-}
-```
-
-### Nested Containers
-
-Flatten nested JSON into a flat Swift struct:
-
-```swift
-// JSON: { "id": 1, "metadata": { "created_at": "...", "tags": [...] } }
-struct Record: Decodable {
-    let id: Int
-    let createdAt: String
-    let tags: [String]
-
-    enum CodingKeys: String, CodingKey {
-        case id, metadata
-    }
-
-    enum MetadataKeys: String, CodingKey {
-        case createdAt = "created_at"
-        case tags
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(Int.self, forKey: .id)
-        let metadata = try container.nestedContainer(
-            keyedBy: MetadataKeys.self, forKey: .metadata)
-        createdAt = try metadata.decode(String.self, forKey: .createdAt)
-        tags = try metadata.decode([String].self, forKey: .tags)
-    }
-}
-```
-
-See [references/swift-patterns-extended.md](references/swift-patterns-extended.md) for additional Codable patterns
-(enums with associated values, date strategies, unkeyed containers).
+Use `CodingKeys` for simple renames and custom decoding only for real payload
+shape or transformation mismatches. Load
+[extended Swift patterns](references/swift-patterns-extended.md) for a compact
+language example; use `swift-codable` for implementation and verification.
 
 ## Modern Collection APIs
 
@@ -414,43 +349,9 @@ let freq = words.reduce(into: [:]) { counts, word in
 
 ## FormatStyle
 
-Use `.formatted()` instead of `DateFormatter`/`NumberFormatter`. It is
-type-safe, localized, and concise.
-
-```swift
-// Dates
-let now = Date.now
-now.formatted()                                       // "3/15/2024, 2:30 PM"
-now.formatted(date: .abbreviated, time: .shortened)   // "Mar 15, 2024, 2:30 PM"
-now.formatted(.dateTime.year().month().day())          // "Mar 15, 2024"
-now.formatted(.relative(presentation: .named))        // "yesterday"
-
-// Numbers
-let price = 42.5
-price.formatted(.currency(code: "USD"))               // "$42.50"
-price.formatted(.percent)                             // "4,250%"
-(1_000_000).formatted(.number.notation(.compactName)) // "1M"
-
-// Measurements
-let distance = Measurement(value: 5, unit: UnitLength.kilometers)
-distance.formatted(.measurement(width: .abbreviated)) // "5 km"
-
-// Duration (Swift 5.7+)
-let duration = Duration.seconds(3661)
-duration.formatted(.time(pattern: .hourMinuteSecond)) // "1:01:01"
-
-// Byte counts
-Int64(1_500_000).formatted(.byteCount(style: .file)) // "1.5 MB"
-
-// Lists
-["Alice", "Bob", "Carol"].formatted(.list(type: .and)) // "Alice, Bob, and Carol"
-```
-
-**Parsing:** `FormatStyle` also supports parsing:
-```swift
-let value = try Decimal("$42.50", format: .currency(code: "USD"))
-let date = try Date("Mar 15, 2024", strategy: .dateTime.month().day().year())
-```
+Use `.formatted()` and `Text(_:format:)` for basic display. Route style
+selection, parsing, localization testing, and reusable formatter design to
+`swift-formatstyle`.
 
 ## String Interpolation
 

--- a/skills/swift-security/SKILL.md
+++ b/skills/swift-security/SKILL.md
@@ -44,6 +44,39 @@ Classify the request before loading references.
 Do not load every reference file by default. This skill is intentionally split
 for progressive disclosure; load only the files needed by the user's task.
 
+### Minimum Safe Keychain Write
+
+Use separate add, identity, and update dictionaries; handle every `OSStatus`:
+
+```swift
+func saveSecret(_ data: Data, account: String) throws {
+    let identity: [CFString: Any] = [
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrService: "com.example.app",
+        kSecAttrAccount: account,
+    ]
+    var add = identity
+    add[kSecValueData] = data
+    add[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+    switch SecItemAdd(add as CFDictionary, nil) {
+    case errSecSuccess:
+        return
+    case errSecDuplicateItem:
+        let status = SecItemUpdate(
+            identity as CFDictionary,
+            [kSecValueData: data] as CFDictionary
+        )
+        guard status == errSecSuccess else { throw KeychainError(status: status) }
+    case let status:
+        throw KeychainError(status: status)
+    }
+}
+```
+
+Load [keychain-fundamentals.md](references/keychain-fundamentals.md) for read,
+delete, access-control, locked-device, and test patterns.
+
 ## Reference Loading
 
 | If the task involves | Load |

--- a/skills/swift-testing/SKILL.md
+++ b/skills/swift-testing/SKILL.md
@@ -116,7 +116,9 @@ When reviewing migration code or plans, do not collapse every XCTest construct i
 
 State coexistence explicitly: XCTest and Swift Testing can coexist during migration. Keep UI automation, performance benchmarks, and common snapshot-test flows on XCTest/XCUITest or snapshot tooling, and separate files or targets when that makes runner expectations clearer.
 
-For Xcode 27-era migrations, mention test framework interoperability when reviewing mixed helpers. Frame what changed: test plans created before Xcode 27 inherit `limited` mode, where cross-framework XCTest issues are warnings; new Xcode 27 projects use `complete` mode, where those issues remain errors. Xcode and SwiftPM can surface XCTest failures from Swift Testing tests and Swift Testing issues from XCTest tests depending on the configured interop mode (`limited`, `complete`, `strict`, or `none`). Prefer `complete` or `strict` while migrating helpers, use `SWIFT_TESTING_XCTEST_INTEROP_MODE` for SwiftPM when needed, and do not claim cross-framework APIs are categorically forbidden. Still prefer native Swift Testing APIs in new Swift Testing tests and convert helper failures to `Issue.record`, `#expect`, `#require`, or `Test.cancel` over time.
+Migrate sequentially: inventory XCTest-only capabilities, migrate one file or suite, compile, run the same tests, compare discovery/pass/fail/skip counts, fix regressions, and only then continue. Do not bulk-rewrite assertions without proving that required unwraps, unconditional failures, async expectations, and setup behavior remain equivalent.
+
+For Xcode 27-era mixed helpers, check the configured interoperability mode rather than claiming cross-framework APIs are forbidden. Older test plans inherit `limited`; new projects use `complete`; `strict` and `none` are also available. Prefer `complete` or `strict` during migration and use `SWIFT_TESTING_XCTEST_INTEROP_MODE` for SwiftPM when needed. See [references/testing-advanced.md](references/testing-advanced.md) for the mode matrix and toolchain gates.
 
 Migration defaults:
 - `XCTAssert*` -> `#expect(...)`
@@ -203,11 +205,7 @@ Test code that calls `exit()`, `fatalError()`, or `preconditionFailure()`. Exit 
 
 ## Version-Gated APIs
 
-For advanced Swift Testing APIs, check the toolchain before recommending them. When reviewing user code that mentions one of these APIs, name the gate for each API you correct:
-- Exit testing requires Swift 6.2 / Xcode 26.0 and does not support iOS, tvOS, or watchOS runtime targets.
-- Exit-test capture lists require the Swift 6.3 compiler. If an exit-test closure reads parent-process values, use an explicit capture list and state that captured values must be `Sendable` and `Codable`.
-- `Test.cancel(_:)`, `Issue.record(_:severity:)`, and image attachment recording require Swift 6.3 / Xcode 26.4-era support as noted in [references/testing-advanced.md](references/testing-advanced.md).
-- When fixing a `Test.cancel(_:)` sample, state both shape and gate: the test must be `throws` or `async throws`, and `Test.cancel(_:)` requires Swift 6.3 / Xcode 26.4-era support.
+For advanced APIs, state the exact toolchain and runtime gate beside the correction. The table below is the canonical summary; [references/testing-advanced.md](references/testing-advanced.md) contains the detailed matrix.
 
 ```swift
 @Test func exitsWithCapturedCode() async {
@@ -220,7 +218,7 @@ For advanced Swift Testing APIs, check the toolchain before recommending them. W
 
 ## Advanced API Review Checklist
 
-When reviewing stale or beta-era Swift Testing samples, include the exact correction and the gate for every API the prompt mentions:
+When reviewing stale or beta-era samples, include the exact correction and gate for every API the prompt mentions:
 
 | User code to correct | Current guidance |
 |---|---|

--- a/skills/swiftdata/SKILL.md
+++ b/skills/swiftdata/SKILL.md
@@ -27,7 +27,9 @@ with Swift 6.3.
 
 ## Model Definition
 
-Apply `@Model` to a **class** (not struct). Generates `PersistentModel`, `Observable`, `Sendable`.
+Apply `@Model` to a **class** (not struct). It synthesizes `PersistentModel`
+conformance. Model instances remain context/actor-bound; pass their
+`PersistentIdentifier`, not the instance, across actors.
 
 ```swift
 @Model
@@ -103,6 +105,13 @@ For any SwiftData CloudKit setup or schema-review task, include a separate
   production changes as additive only.
 
 ## CRUD Operations
+
+For destructive batches and migrations, first run the exact predicate or
+version hop against a disposable copy and record affected identifiers/counts.
+Execute with explicit transaction/save semantics, refetch, and verify values,
+relationships, counts, and invariants. On failure, fix the predicate/schema and
+restore a pristine fixture before retrying; never blindly replay a destructive
+operation.
 
 ```swift
 // CREATE
@@ -225,6 +234,8 @@ static let migrateV2toV3 = MigrationStage.custom(
 ```
 
 Lightweight handles: adding optional/defaulted properties, renaming (`originalName`), removing properties, adding model types.
+Verify the stage list covers every supported version hop, then migrate a fresh
+copy of each old store and assert post-migration data before release.
 
 ## Core Data Coexistence Boundary
 

--- a/skills/swiftui-animation/SKILL.md
+++ b/skills/swiftui-animation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-animation
-description: "Implement, review, or improve SwiftUI animations and transitions. Use when adding explicit animations with withAnimation, configuring implicit animations with .animation(_:body:) or .animation(_:value:), configuring spring animations (.smooth, .snappy, .bouncy), building phase or keyframe animations with PhaseAnimator/KeyframeAnimator, creating hero transitions with matchedGeometryEffect or matchedTransitionSource, adding SF Symbol effects (iOS 17 bounce, pulse, variableColor, scale, appear, disappear, replace; iOS 18 breathe, rotate, wiggle), implementing custom Transition or CustomAnimation types, or ensuring animations respect accessibilityReduceMotion."
+description: "Implement, diagnose, or review SwiftUI motion using explicit and scoped implicit animations, springs, transitions, PhaseAnimator, KeyframeAnimator, matched geometry or navigation zoom, SF Symbol effects, and custom Animation types. Use when views should animate on state changes, insertion, removal, navigation, or multi-step choreography, or when motion must respect Reduce Motion and Swift concurrency."
 ---
 
 # SwiftUI Animation (iOS 26+)
@@ -47,26 +47,15 @@ correct timing, transitions, and accessibility handling using Swift 6.3 patterns
 ### Step 2: Choose the animation curve
 
 ```swift
-// Timing curves
-.linear                              // constant speed
-.easeIn(duration: 0.3)              // slow start
-.easeOut(duration: 0.3)             // slow end
-.easeInOut(duration: 0.3)           // slow start and end
-.timingCurve(.bezier(startControlPoint: .zero, endControlPoint: .init(x: 1, y: 1)), duration: 0.3)
-
-// Spring presets (preferred for natural motion)
-.smooth                              // no bounce, fluid
-.smooth(duration: 0.5, extraBounce: 0.0)
-.snappy                              // small bounce, responsive
-.snappy(duration: 0.4, extraBounce: 0.1)
-.bouncy                              // visible bounce, playful
-.bouncy(duration: 0.5, extraBounce: 0.2)
-
-// Custom spring
-.spring(duration: 0.5, bounce: 0.3, blendDuration: 0.0)
-.spring(Spring(duration: 0.6, bounce: 0.2), blendDuration: 0.0)
-.interactiveSpring(response: 0.15, dampingFraction: 0.86)
+.easeInOut(duration: 0.3)       // mechanical timing
+.smooth                         // fluid, no bounce
+.snappy                         // responsive, small bounce
+.bouncy                         // playful, visible bounce
+.spring(duration: 0.5, bounce: 0.3)
 ```
+
+Use [the advanced catalog](references/animation-advanced.md#spring-type-all-initializer-variants)
+when presets do not express the intended motion.
 
 ### Step 3: Apply and verify
 
@@ -110,23 +99,15 @@ Circle()
 
 ## Spring Type (iOS 17+)
 
-Four initializer forms for different mental models.
+Prefer the perceptual form or a preset. Load the advanced reference only when
+physical, response-based, or settling parameters are required.
 
 ```swift
-// Perceptual (preferred)
 Spring(duration: 0.5, bounce: 0.3)
-
-// Physical
-Spring(mass: 1.0, stiffness: 100.0, damping: 10.0)
-
-// Response-based
-Spring(response: 0.5, dampingRatio: 0.7)
-
-// Settling-based
-Spring(settlingDuration: 1.0, dampingRatio: 0.8)
+Spring.smooth
+Spring.snappy
+Spring.bouncy
 ```
-
-Three presets mirror Animation presets: `.smooth`, `.snappy`, `.bouncy`.
 
 ## PhaseAnimator (iOS 17+)
 
@@ -324,10 +305,8 @@ if showBanner {
 }
 ```
 
-Built-in types: `.opacity`, `.slide`, `.scale`, `.scale(_:anchor:)`,
-`.move(edge:)`, `.push(from:)`, `.offset(x:y:)`, `.identity`,
-`.blurReplace`, `.blurReplace(_:)`, `.symbolEffect`,
-`.symbolEffect(_:options:)`.
+See [All Transition Types](references/animation-advanced.md#all-transition-types-ios-17)
+for the built-in catalog and custom `Transition` examples.
 
 Asymmetric transitions:
 
@@ -385,38 +364,12 @@ Image(systemName: "speaker.wave.3.fill")
     )
 ```
 
-Availability: iOS 17+ for `.bounce`, `.pulse`, `.variableColor`, `.scale`,
-`.appear`, `.disappear`, `.replace`; iOS 18+ for `.breathe`, `.rotate`,
-`.wiggle`.
-
 Scope: `.byLayer`, `.wholeSymbol`. Direction varies per effect.
 
 ## Symbol Rendering Modes
 
-Control how SF Symbol layers are colored with `.symbolRenderingMode(_:)`.
-
-| Mode | Effect | When to use |
-|------|--------|-------------|
-| `.monochrome` | Single color applied uniformly (default) | Toolbars, simple icons matching text |
-| `.hierarchical` | Single color with opacity layers for depth | Subtle depth without multiple colors |
-| `.multicolor` | System-defined fixed colors per layer | Weather, file types — Apple's intended palette |
-| `.palette` | Custom colors per layer via `.foregroundStyle` | Brand colors, custom multi-color icons |
-
-```swift
-// Hierarchical — single tint, opacity layers for depth
-Image(systemName: "speaker.wave.3.fill")
-    .symbolRenderingMode(.hierarchical)
-    .foregroundStyle(.blue)
-
-// Palette — custom color per layer
-Image(systemName: "person.crop.circle.badge.plus")
-    .symbolRenderingMode(.palette)
-    .foregroundStyle(.blue, .green)
-
-// Multicolor — system-defined colors
-Image(systemName: "cloud.sun.rain.fill")
-    .symbolRenderingMode(.multicolor)
-```
+Choose `.monochrome`, `.hierarchical`, `.multicolor`, or `.palette` with
+`.symbolRenderingMode(_:)`; use `.foregroundStyle` to supply palette colors.
 
 **Variable symbols:** use `Image(systemName:variableValue:)` (iOS 16+) for percentage fill. Use `.symbolVariableValueMode(_:)` (iOS 26+) to choose `.draw` or `.color`.
 

--- a/skills/swiftui-layout-components/references/list.md
+++ b/skills/swiftui-layout-components/references/list.md
@@ -1,5 +1,15 @@
 # List and Section
 
+## Contents
+
+- [Intent](#intent)
+- [Core patterns](#core-patterns)
+- [Example: feed list with scroll-to-top](#example-feed-list-with-scroll-to-top)
+- [Example: settings-style list](#example-settings-style-list)
+- [Design choices to keep](#design-choices-to-keep)
+- [iOS 26 Scroll Edge Effects](#ios-26-scroll-edge-effects)
+- [Pitfalls](#pitfalls)
+
 ## Intent
 
 Use `List` for feed-style content and settings-style rows where built-in row reuse, selection, and accessibility matter.

--- a/skills/swiftui-liquid-glass/SKILL.md
+++ b/skills/swiftui-liquid-glass/SKILL.md
@@ -51,7 +51,7 @@ Choose the path that matches the request:
 
 ### 3. Review existing Liquid Glass usage
 
-Run through the Review Checklist below and verify each item.
+Trace each effect through content/control ownership, layout order, container scope, interactivity, transitions, availability, accessibility settings, and fallback. Restore the same UI fixture and rerun the checklist after each correction.
 
 ## Core API Summary
 
@@ -289,83 +289,14 @@ VStack(spacing: 8) {
 
 ## Common Mistakes
 
-### DON'T: Apply Liquid Glass to every surface
-
-Overuse distracts from content. Liquid Glass belongs in the controls/navigation layer;
-do not use it to decorate static content containers.
-
-```swift
-// WRONG: Glass on everything
-VStack {
-    Text("Title").glassEffect()
-    Text("Subtitle").glassEffect()
-    Divider().glassEffect()
-    Text("Body").glassEffect()
-}
-
-// CORRECT: Static content stays in the content layer
-VStack {
-    Text("Title").font(.title)
-    Text("Subtitle").font(.subheadline)
-    Divider()
-    Text("Body")
-}
-
-Button("Add") { addItem() }
-    .buttonStyle(.glass)
-```
-
-### DON'T: Make static status look tappable
-
-Counts, badges, summaries, and read-only status chips should not live in toolbar
-action slots or use `.interactive()` unless they initiate an immediate action. If a
-badge belongs to a real toolbar action, make the action one accessible control and
-keep the badge subordinate to that control.
-
-### DON'T: Nest GlassEffectContainer for one related group
-
-Use one container for the related glass group so rendering, blending, and morphing
-scope stay predictable.
-
-```swift
-// WRONG
-GlassEffectContainer {
-    GlassEffectContainer {
-        content.glassEffect()
-    }
-}
-
-// CORRECT: Single container wrapping all glass views
-GlassEffectContainer {
-    content.glassEffect()
-}
-```
-
-### DON'T: Add .interactive() to non-interactive elements
-
-`.interactive()` adds visual affordance suggesting tappability. Using it on decorative
-or read-only status glass misleads users.
-
-### DON'T: Apply .glassEffect() before layout modifiers
-
-Glass calculates its shape from the final frame. Applying it before padding/frame produces incorrect bounds.
-
-```swift
-// WRONG: Glass applied before padding
-Text("Label").glassEffect().padding()
-
-// CORRECT: Glass applied after layout
-Text("Label").padding().glassEffect()
-```
-
-### DON'T: Forget accessibility testing
-
-Always test with Reduce Transparency and Reduce Motion enabled. System settings can
-remove or modify translucency and motion, so verify custom glass content remains readable.
-
-### DON'T: Skip availability checks
-
-Liquid Glass requires iOS 26+. Gate with `if #available(iOS 26, *)` and provide a fallback.
+| Mistake | Fix |
+|---|---|
+| Glass decorates static content | Keep it in the controls/navigation layer. |
+| Read-only status uses `.interactive()` or an action slot | Present status as content, or make the whole badge one real accessible action. |
+| Related effects use nested containers | Use one `GlassEffectContainer` per related blending/morphing group. |
+| `.glassEffect()` precedes padding/frame/style | Apply layout and appearance first, then glass. |
+| Custom effects assume default accessibility settings | Test Reduce Transparency, Reduce Motion, contrast, and legibility. |
+| No pre-iOS 26 path | Gate the effect and preserve a functional fallback. |
 
 ## Review Checklist
 

--- a/skills/swiftui-navigation/SKILL.md
+++ b/skills/swiftui-navigation/SKILL.md
@@ -156,6 +156,8 @@ Prefer `.sheet(item:)` over `.sheet(isPresented:)` when state represents a selec
 Fine-tuning: `.fitted(horizontal:vertical:)` constrains fitting axes; `.sticky(horizontal:vertical:)` grows but does not shrink in specified dimensions.
 
 **Dismissal protection:** On iOS/iPadOS, use `.interactiveDismissDisabled(hasUnsavedChanges)` and provide explicit Save/Discard actions inside the sheet. On macOS 15+, use `.dismissalConfirmationDialog("Discard?", shouldPresent: hasUnsavedChanges)` for window dismissal confirmation.
+Route every programmatic close through the same save/validate/discard gate;
+`interactiveDismissDisabled` guards interactive dismissal only.
 
 **Enum-driven sheet routing:** Define a `SheetDestination` enum that is `Identifiable`, store it on the router, and map it with a shared view modifier. This lets any child view present sheets without prop-drilling. See [references/sheets.md](references/sheets.md) for the full centralized sheet routing pattern.
 
@@ -197,6 +199,11 @@ struct MainTabView: View {
 See [references/tabview.md](references/tabview.md) for full TabView patterns including custom bindings, dynamic tabs, and sidebar customization.
 
 ## Deep Links
+
+Use parse → validate → commit. Parse into a typed route without mutating
+navigation; validate scheme/host/path, identifier shape, authorization, and
+destination existence; then update tab/path atomically. Invalid links must leave
+the current navigation unchanged.
 
 ### Universal Links
 

--- a/skills/swiftui-navigation/references/deeplinks.md
+++ b/skills/swiftui-navigation/references/deeplinks.md
@@ -33,16 +33,18 @@ final class RouterPath {
   var urlHandler: ((URL) -> OpenURLAction.Result)?
 
   func handle(url: URL) -> OpenURLAction.Result {
-    if isInternal(url) {
-      navigate(to: .status(id: url.lastPathComponent))
-      return .handled
+    guard let route = parseInternal(url), isAuthorized(route), destinationExists(route) else {
+      return urlHandler?(url) ?? .systemAction
     }
-    return urlHandler?(url) ?? .systemAction
+    path.append(route) // Commit only after every validation passes.
+    return .handled
   }
 
   func handleDeepLink(url: URL) -> OpenURLAction.Result {
-    // Resolve federated URLs, then navigate.
-    navigate(to: .status(id: url.lastPathComponent))
+    guard let route = parseInternal(url), isAuthorized(route), destinationExists(route) else {
+      return .discarded
+    }
+    path.append(route)
     return .handled
   }
 }
@@ -75,7 +77,8 @@ extension View {
 
 ## Pitfalls
 
-- Don’t assume the URL is internal; validate first.
+- Parse and validate before mutating any tab or navigation path. Invalid links
+  must leave current navigation unchanged.
 - Avoid blocking UI while resolving remote links; use `Task`.
 
 ## Universal Links

--- a/skills/swiftui-navigation/references/sheets.md
+++ b/skills/swiftui-navigation/references/sheets.md
@@ -151,6 +151,10 @@ On iOS/iPadOS, prevent gesture dismissal while unsaved changes exist and expose 
 }
 ```
 
+`interactiveDismissDisabled` covers interactive dismissal. Route toolbar
+buttons and other programmatic close paths through the same validation/save or
+explicit-discard decision before calling `dismiss()`.
+
 On macOS 15+, show a confirmation dialog when the user tries to dismiss a sheet with unsaved changes:
 
 ```swift

--- a/skills/swiftui-patterns/SKILL.md
+++ b/skills/swiftui-patterns/SKILL.md
@@ -10,6 +10,7 @@ Modern SwiftUI patterns targeting iOS 26+ with Swift 6.3. Covers architecture, s
 ## Contents
 
 - [Architecture: Model-View (MV) Pattern](#architecture-model-view-mv-pattern)
+- [Workflow](#workflow)
 - [State Management](#state-management)
 - [View Ordering Convention](#view-ordering-convention)
 - [View Composition](#view-composition)
@@ -24,6 +25,16 @@ Modern SwiftUI patterns targeting iOS 26+ with Swift 6.3. Covers architecture, s
 - [References](#references)
 
 **Scope boundary:** This skill covers architecture, state ownership, composition, environment wiring, async loading, and related SwiftUI app structure patterns. Detailed navigation patterns are covered in the `swiftui-navigation` skill, including `NavigationStack`, `NavigationSplitView`, sheets, tabs, and deep-linking patterns. Detailed layout, container, and component patterns are covered in the `swiftui-layout-components` skill, including stacks, grids, lists, scroll view patterns, forms, controls, search UI with `.searchable`, overlays, and related layout components. Detailed animation choreography is covered in `swiftui-animation`. Liquid Glass adoption, custom glass controls, scroll edge effects, `.scrollEdgeEffectStyle`, and `.backgroundExtensionEffect` are covered in `swiftui-liquid-glass`.
+
+## Workflow
+
+1. Record the current state ownership, actions, side effects, navigation, and lifecycle behavior.
+2. Choose the smallest MV/state/composition change that preserves that contract.
+3. Build after each structural step; fix compiler and isolation errors before continuing.
+4. Render deterministic previews for loaded, loading, empty, and error states as applicable, including required environment dependencies.
+5. Exercise important interactions and side effects. If behavior changes, restore the fixture, fix the smallest boundary, and rerun the same build, preview, and interaction checks.
+
+Load [Behavior-Preserving View Refactoring](references/view-refactoring.md) for restructuring existing views and [Isolated Preview Construction](references/preview-isolation.md) for fixture and dependency patterns.
 
 ## Architecture: Model-View (MV) Pattern
 
@@ -286,12 +297,7 @@ Use `swift-concurrency` for cancellation handlers, debounce and clocks, `AsyncSe
 
 ## iOS 26+ New APIs
 
-- **`.scrollEdgeEffectStyle(.soft, for: .top)`** -- fading edge effect on scroll edges
-- **`.backgroundExtensionEffect()`** -- mirror/blur at safe area edges
-- **`@Animatable`** macro -- synthesizes `AnimatableData` conformance automatically (see `swiftui-animation` skill)
-- **`TextEditor(text: Binding<AttributedString>)`** -- rich text editing with attributed strings
-
-Keep these as routing reminders in this skill. For Liquid Glass visual treatment, scroll edge effects, glass controls, and availability gating, use `swiftui-liquid-glass`; for detailed animation APIs, use `swiftui-animation`.
+Route `.scrollEdgeEffectStyle`, `.backgroundExtensionEffect`, and glass controls to `swiftui-liquid-glass`; route `@Animatable` to `swiftui-animation`. `TextEditor(text: Binding<AttributedString>)` is the iOS 26 rich-text editing path. Keep availability checks beside code that adopts these APIs.
 
 Clipboard command modifiers are not iOS 26 defaults: `.copyable`, `.cuttable`, and command-based `.pasteDestination(for:action:validator:)` are macOS 13+ and iOS/iPadOS/Mac Catalyst 27 beta in current Apple docs. For iOS 26 targets, use `UIPasteboard` for custom clipboard commands, or use drag/drop and `ShareLink` for `Transferable` flows. See [references/platform-and-sharing.md](references/platform-and-sharing.md).
 
@@ -351,25 +357,7 @@ TextField("Search…", text: $query)
 10. Inline closures in body -- extract complex closures to methods
 11. `.sheet(isPresented:)` when state represents a model -- use `.sheet(item:)` instead
 12. **Using `AnyView` for routine branching** -- type erasure hides structure and can hurt performance or identity-sensitive transitions. Use `@ViewBuilder`, `Group`, or generics unless an API genuinely needs heterogeneous view storage. See [references/deprecated-migration.md](references/deprecated-migration.md)
-13. **Putting `@AppStorage` inside an `@Observable` class** -- `@AppStorage` is a SwiftUI `DynamicProperty`; it only triggers view updates when used directly in a `View`. Inside an `@Observable` class, observation tracking never sees the change. Keep `@AppStorage` in views, or read/write `UserDefaults` directly inside the `@Observable` class:
-
-```swift
-// Wrong -- @AppStorage is invisible to @Observable tracking
-@MainActor @Observable final class Settings {
-    @AppStorage("theme") var theme: String = "system" // view won't update
-}
-
-// Right -- UserDefaults read/write with a normal stored property
-@MainActor @Observable final class Settings {
-    var theme: String {
-        didSet { UserDefaults.standard.set(theme, forKey: "theme") }
-    }
-
-    init() {
-        theme = UserDefaults.standard.string(forKey: "theme") ?? "system"
-    }
-}
-```
+13. **Putting `@AppStorage` inside an `@Observable` class.** `@AppStorage` is a view `DynamicProperty`; keep it in a `View`, or expose a normal observed property backed by `UserDefaults` in the model.
 
 14. Hard-coding `spacing:` on every stack -- omit it to get adaptive platform spacing; only specify when the value is intentional
 15. Treating `.copyable`, `.cuttable`, or command-based `.pasteDestination(for:action:validator:)` as iOS 16/iOS 26 APIs -- they are macOS 13+ and iOS/iPadOS/Mac Catalyst 27 beta in current Apple docs. Use `UIPasteboard`, drag/drop, or `ShareLink` for iOS 26 targets.

--- a/skills/swiftui-performance/SKILL.md
+++ b/skills/swiftui-performance/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: swiftui-performance
-description: "Audit and improve SwiftUI runtime performance. Use when diagnosing slow rendering, janky scrolling, high CPU, memory usage, excessive view updates, layout thrash, body evaluation cost, identity churn, view lifetime issues, lazy loading, Instruments profiling guidance, and performance audit requests."
+description: "Profile, diagnose, and remediate SwiftUI runtime performance using code review, Instruments, and repeatable measurements. Use when a SwiftUI screen renders slowly, scrolling or animations hitch, view bodies update excessively, list identity churns, layout work spikes, or broad Observation dependencies raise CPU cost. Covers evidence-based triage, SwiftUI Instruments lanes, lazy-container guardrails, state lifetime, and before/after verification."
 ---
 
 # SwiftUI Performance
 
-Audit SwiftUI view performance end-to-end, from instrumentation and baselining to root-cause analysis and concrete remediation steps.
+Audit SwiftUI view performance from a reproducible symptom to measured
+remediation. Route animation design to `swiftui-animation`, production telemetry
+to `metrickit`, ownership/leak analysis to `ios-memgraph-analysis`, navigation
+behavior to `swiftui-navigation`, state architecture to `swiftui-patterns`, and
+layout construction to `swiftui-layout-components`.
 
 ## Contents
 
@@ -27,58 +31,39 @@ Audit SwiftUI view performance end-to-end, from instrumentation and baselining t
 
 ## Workflow Decision Tree
 
-- If the user provides code, start with "Code-First Review."
-- If the user only describes symptoms, ask for minimal code/context, then do "Code-First Review."
-- If code review is inconclusive, go to "Guide the User to Profile" and ask for a trace or screenshots.
+- Code supplied: review it first and label findings as hypotheses.
+- Symptoms only: collect the smallest relevant view, data flow, reproduction,
+  device, OS, and build configuration.
+- Inconclusive review: collect a trace or lane screenshots before prescribing a
+  broad refactor.
+
+Use this triage list for both code and trace analysis:
+
+- Broad state dependencies or invalidation storms
+- Unstable list identity or root conditional swapping
+- Formatting, sorting, decoding, or synchronous I/O in `body`
+- Layout/geometry feedback loops and oversized images
+- Implicit animation applied to a large hierarchy
 
 ## 1. Code-First Review
 
-Collect:
-- Target view/feature code.
-- Data flow: state, environment, observable models.
-- Symptoms and reproduction steps.
-
-Focus on:
-- View invalidation storms from broad state changes.
-- Unstable identity in lists (`id` churn, `UUID()` per render).
-- Top-level conditional view swapping (`if/else` returning different root branches).
-- Heavy work in `body` (formatting, sorting, image decoding).
-- Layout thrash (deep stacks, `GeometryReader`, preference chains).
-- Large images without downsampling or resizing.
-- Over-animated hierarchies (implicit animations on large trees).
-
-Provide:
-- Likely root causes with code references, labeled as code-backed hypotheses until a trace confirms them.
-- Suggested fixes and refactors.
-- If needed, a minimal repro or instrumentation suggestion.
+Map each suspect from the triage list to exact code. Report likely causes with
+code references, but label them code-backed hypotheses until a trace confirms
+cost. Propose a minimal repro or measurement when evidence is missing.
 
 ## 2. Guide the User to Profile
 
-Explain how to collect data with Instruments:
-- Use the SwiftUI template in Instruments.
-- Profile a **Release build** on a real device when possible.
-- Reproduce the exact interaction (scroll, navigation, animation).
-- Capture SwiftUI lanes, Time Profiler, and Hangs/Hitches when relevant.
-- Export or screenshot the relevant lanes and the call tree.
-
-Ask for:
-- Trace export or screenshots of SwiftUI lanes + Time Profiler call tree.
-- Device/OS/build configuration.
+Use the SwiftUI Instruments template on a **Release build** and real device when
+possible. Reproduce the exact interaction, capturing SwiftUI lanes, Time
+Profiler, and Hangs/Hitches as relevant. Ask for the trace or screenshots of the
+lanes and call tree.
 
 ## 3. Analyze and Diagnose
 
-Prioritize likely SwiftUI culprits:
-- View invalidation storms from broad state changes.
-- Unstable identity in lists (`id` churn, `UUID()` per render).
-- Top-level conditional view swapping (`if/else` returning different root branches).
-- Heavy work in `body` (formatting, sorting, image decoding).
-- Layout thrash (deep stacks, `GeometryReader`, preference chains).
-- Large images without downsampling or resizing.
-- Over-animated hierarchies (implicit animations on large trees).
-
-Summarize findings with evidence from traces/logs. Distinguish trace-backed findings
-from code-backed hypotheses and name the next measurement that would resolve any
-remaining uncertainty.
+Apply the same triage list to trace evidence. Correlate long or frequent SwiftUI
+updates with the Time Profiler call tree and the reproduced interaction. Separate
+trace-backed findings from code-backed hypotheses and name the next measurement
+that would resolve remaining uncertainty.
 
 ## 4. Remediate
 
@@ -96,96 +81,13 @@ Apply targeted fixes:
 
 ## Common Code Smells (and Fixes)
 
-Look for these patterns during code review.
-
-### Expensive formatters in `body`
-
-```swift
-var body: some View {
-    let number = NumberFormatter() // slow allocation
-    let measure = MeasurementFormatter() // slow allocation
-    Text(measure.string(from: .init(value: meters, unit: .meters)))
-}
-```
-
-Prefer cached formatters in a model or a dedicated helper:
-
-```swift
-final class DistanceFormatter {
-    static let shared = DistanceFormatter()
-    let number = NumberFormatter()
-    let measure = MeasurementFormatter()
-}
-```
-
-### Computed properties that do heavy work
-
-```swift
-var filtered: [Item] {
-    items.filter { $0.isEnabled } // runs on every body eval
-}
-```
-
-Prefer precomputing when the source inputs change. Put the transformation in the
-model or a dedicated helper, or use view-owned derived state only when the view also
-defines the exact input change that refreshes it.
-
-### Sorting/filtering in `body` or `ForEach`
-
-```swift
-// DON'T: sorts or filters on every body evaluation
-ForEach(items.sorted(by: sortRule)) { item in Row(item) }
-ForEach(items.filter { $0.isEnabled }) { item in Row(item) }
-```
-
-Prefer precomputed, cached collections with stable identity. Update on input change, not in `body`.
-
-### Unstable identity
-
-```swift
-ForEach(items, id: \.self) { item in
-    Row(item)
-}
-```
-
-Avoid `id: \.self` for non-stable values; use a stable ID.
-
-### Top-level conditional view swapping
-
-```swift
-var content: some View {
-    if isEditing {
-        editingView
-    } else {
-        readOnlyView
-    }
-}
-```
-
-Prefer one stable base view and localize conditions to sections/modifiers (for example inside `toolbar`, row content, `overlay`, or `disabled`). This reduces root identity churn and helps SwiftUI diffing stay efficient.
-
-### Image decoding on the main thread
-
-```swift
-Image(uiImage: UIImage(data: data)!)
-```
-
-Prefer decode/downsample off the main thread and store the result.
-
-### Broad dependencies in observable models
-
-```swift
-@Observable class Model {
-    var items: [Item] = []
-}
-
-var body: some View {
-    Row(isFavorite: model.items.contains(item))
-}
-```
-
-Prefer narrower derived inputs, smaller observable surfaces, or per-item state to
-reduce update fan-out. Do not introduce view models solely as a performance ritual.
+| Smell | Evidence to seek | Targeted fix |
+|---|---|---|
+| Formatter, sort, filter, or decode in `body` | Long/frequent body updates with matching call-tree cost | Recompute when inputs change; downsample/decode off the main actor |
+| `UUID()` or unstable `id: \.self` | Recreated rows, lost state, excess updates | Use stable model identity |
+| Root `if`/`else` swaps | State reset or update spikes when toggled | Localize conditional content/modifiers when semantics allow |
+| Broad model reads | Many unrelated views update together | Pass narrow values or move reads into focused child views |
+| Geometry writes during layout | Repeating layout/update cycle | Threshold changes or replace the feedback path with stable layout |
 
 ## 5. Verify
 
@@ -218,217 +120,45 @@ See [references/optimizing-swiftui-performance-instruments.md](references/optimi
 
 ## Identity and Lifetime
 
-### Structural Identity vs Explicit Identity
-
-SwiftUI assigns every view an **identity** used to track its lifetime, state, and animations.
-
-- **Structural identity** (default): determined by the view's position in the view hierarchy. SwiftUI uses the call-site location in `body` to distinguish views.
-- **Explicit identity**: you assign with `.id(_:)` modifier or `ForEach(items, id: \.stableID)`.
-
-```swift
-// Structural identity: SwiftUI knows these are different views by position
-VStack {
-    Text("First")   // position 0
-    Text("Second")  // position 1
-}
-```
-
-### How Identity Tracks View Lifetime
-
-When a view's identity changes, SwiftUI treats it as a **new view**:
-
-- All `@State` is reset.
-- `onAppear` fires again.
-- Animations may restart.
-- Transition animations play (if defined).
-
-When identity stays the same, SwiftUI updates the **existing view** in place, preserving state and providing smooth transitions.
-
-### AnyView in Hot Paths
-
-`AnyView` erases concrete view type information. In hot list or table rows, that can hide structural information SwiftUI uses for row shape and diffing:
+Identity controls view lifetime and state. Use stable model IDs in repeated
+content and reserve `.id(_:)` changes for intentional resets. Prefer
+`@ViewBuilder` or generic composition over `AnyView` in profiled hot rows. Treat
+root conditional branches as suspects—not automatic defects—when evidence shows
+state churn or expensive recreation.
 
 ```swift
-// DON'T: AnyView hides row structure in hot paths
-func makeView(for item: Item) -> AnyView {
-    if item.isPremium {
-        return AnyView(PremiumRow(item: item))
-    } else {
-        return AnyView(StandardRow(item: item))
-    }
-}
-
-// DO: use @ViewBuilder to preserve structural identity
-@ViewBuilder
-func makeView(for item: Item) -> some View {
-    if item.isPremium {
-        PremiumRow(item: item)
-    } else {
-        StandardRow(item: item)
-    }
-}
-```
-
-Prefer `@ViewBuilder` or generic composition in repeated subtrees. Keep type erasure at API boundaries unless profiling proves it is harmless in that path.
-
-### Ternary Modifiers Preserve Structural Identity
-
-`if`/`else` in a view builder creates `_ConditionalContent` — two separate view branches with distinct identities. When the condition changes, SwiftUI destroys one branch and creates the other, resetting all `@State`.
-
-For toggling **modifiers** on the same view, use a ternary expression instead:
-
-```swift
-// DON'T: if/else creates two separate Text views with different identities
-if isHighlighted {
-    Text(title).foregroundStyle(.yellow)
-} else {
-    Text(title).foregroundStyle(.primary)
-}
-
-// DO: ternary keeps one Text view, just changes the modifier value
 Text(title)
     .foregroundStyle(isHighlighted ? .yellow : .primary)
-```
 
-This preserves the view's identity (and its state) across the condition change, and SwiftUI can animate the transition smoothly.
-
-Use `if`/`else` when the **view type itself** differs between branches. Use ternary when only a **property or modifier** changes.
-
-### id() Modifier Impacts
-
-The `.id()` modifier assigns explicit identity. Changing the value **destroys and recreates** the view:
-
-```swift
-// DON'T: UUID() changes every render, destroying and recreating the view each time
-ScrollView {
-    LazyVStack {
-        ForEach(items) { item in
-            Row(item: item)
-                .id(UUID())  // kills performance -- new identity every render
-        }
-    }
-}
-
-// DO: use a stable identifier
 ForEach(items) { item in
-    Row(item: item)
-        .id(item.stableID)  // identity only changes when the item actually changes
+    Row(item: item).id(item.stableID)
 }
 ```
-
-Intentional `.id()` change is useful for **resetting state** (e.g., `.id(selectedTab)` to reset a scroll position when switching tabs).
 
 ## Lazy Loading Patterns
 
-### LazyVStack and LazyHStack
+Use lazy containers when profiling shows eager construction, layout, or update
+work is material; there is no universal item-count threshold. Route grid/list
+construction choices to `swiftui-layout-components`.
 
-Lazy stacks evaluate and render only the portion SwiftUI needs for the current scroll position and nearby prefetching, instead of eagerly materializing every child.
+Guardrails:
 
-```swift
-ScrollView {
-    LazyVStack {
-        ForEach(items) { item in
-            ItemRow(item: item)
-        }
-    }
-}
-```
-
-Key behaviors:
 - Off-screen views are removed from the lazy stack. SwiftUI may keep them briefly, then delete the views and their view-local state.
 - Persist important row state outside the row view if it must survive scrolling away.
 - Body and layout work can happen before `onAppear` because of prefetching. Do not make `onAppear` the only setup point for data a row needs to render.
 - Treat `onAppear` and `onDisappear` as visibility signals, not lifetime guarantees.
-
-### LazyVGrid and LazyHGrid
-
-Use lazy grids for multi-column layouts:
-
-```swift
-// Adaptive: as many columns as fit with minimum width
-let columns = [GridItem(.adaptive(minimum: 150))]
-
-ScrollView {
-    LazyVGrid(columns: columns) {
-        ForEach(photos) { photo in
-            PhotoThumbnail(photo: photo)
-        }
-    }
-}
-
-// Fixed: exact number of equal columns
-let fixedColumns = [
-    GridItem(.flexible()),
-    GridItem(.flexible()),
-    GridItem(.flexible()),
-]
-```
-
-### Lazy Container Guardrails
-
 - Filter data before `ForEach`; avoid `if` branches that make each element produce zero or one row.
 - Keep each `ForEach` element to a constant number of top-level subviews. Wrap row contents in a stable container if needed. Use `-LogForEachSlowPath YES` while debugging list/table slow paths.
 - Avoid absolute content-size or content-offset assumptions; lazy stacks estimate off-screen sizes.
 - Avoid geometry feedback loops in lazy rows. Prefer stable sizing, layout primitives, or a custom `Layout` before feeding geometry changes back into row state.
 
-### When to Use Lazy vs Eager Stacks
-
-No item-count threshold makes lazy containers automatically correct. Start with the simplest container that matches the UI, then switch when profiling shows eager construction, layout, or update work is material.
-
-| Scenario | Default |
-|----------|---------|
-| Small, fixed, fully visible content | `VStack` / `HStack` |
-| Large or unbounded custom scroll content | `LazyVStack` / `LazyHStack`, then profile |
-| System-style rows, edit actions, swipe actions, or very large feeds | `List` is often the better starting point |
-| Always-visible content | Eager stack; lazy adds bookkeeping without benefit |
-| Custom scroll control with many rows | `LazyVStack` inside `ScrollView`, with stable identity and constant row shape |
-
-**Important:** Avoid unconstrained `GeometryReader` in lazy rows when it drives row size or shared state. Use stable sizing, layout APIs, or narrowly scoped `.onGeometryChange` (iOS 16+) that thresholds values and does not invalidate the whole list.
-
 ## State and Observation Optimization
 
-### `@Observable` Granular Tracking
-
-`@Observable` (Observation framework, iOS 17+) tracks property access at the **per-property level**. A view only re-evaluates when properties it actually read in `body` change:
-
-```swift
-@Observable class UserProfile {
-    var name: String = ""
-    var avatarURL: URL?
-    var biography: String = ""
-}
-
-// This view ONLY re-renders when `name` changes -- not when
-// biography or avatarURL change, because it only reads `name`
-struct NameLabel: View {
-    let profile: UserProfile
-    var body: some View {
-        Text(profile.name)
-    }
-}
-```
-
-This is a significant improvement over `ObservableObject` + `@Published`, which invalidates all observing views when **any** published property changes.
-
-### Avoiding Observation Scope Pollution
-
-If a view reads many properties from an `@Observable` model in `body`, it re-renders when **any** of those properties change. Push reads into child views to narrow the scope:
+Observation tracks properties read during view evaluation. Reduce fan-out by
+passing narrow derived values or moving reads into focused child views.
 
 ```swift
-// DON'T: reads name, email, avatar, and settings in one body
-struct ProfileView: View {
-    let model: ProfileModel
-    var body: some View {
-        VStack {
-            Text(model.name)           // tracks name
-            Text(model.email)          // tracks email
-            AsyncImage(url: model.avatar) // tracks avatar
-            SettingsForm(model.settings)  // tracks settings
-        }
-    }
-}
-
-// DO: split into child views so each only tracks what it reads
+// Split reads into child views so each tracks only what it renders.
 struct ProfileView: View {
     let model: ProfileModel
     var body: some View {
@@ -442,20 +172,10 @@ struct ProfileView: View {
 }
 ```
 
-### Computed Properties for Derived State
-
-Use computed properties on `@Observable` models to derive state without introducing extra stored properties that widen observation scope:
-
-```swift
-@Observable class ShoppingCart {
-    var items: [CartItem] = []
-
-    // Views reading `total` only re-render when `items` changes
-    var total: Decimal {
-        items.reduce(0) { $0 + $1.price * Decimal($1.quantity) }
-    }
-}
-```
+Cheap computed values can remain derived; expensive transformations need an
+explicit owner, input set, and refresh trigger. Do not add view models as a
+performance ritual—measure first and route general state design to
+`swiftui-patterns`.
 
 ## Common Mistakes
 

--- a/skills/swiftui-uikit-interop/SKILL.md
+++ b/skills/swiftui-uikit-interop/SKILL.md
@@ -5,7 +5,7 @@ description: "Bridges UIKit and SwiftUI with UIViewRepresentable, UIViewControll
 
 # SwiftUI-UIKit Interop
 
-Bridge UIKit and SwiftUI in both directions. Wrap UIKit views and view controllers for use in SwiftUI, embed SwiftUI views inside UIKit screens, and synchronize state across the boundary. Targets iOS 26+ with Swift 6.3 patterns; notes backward-compatible to iOS 16 unless stated otherwise.
+Bridge UIKit and SwiftUI in both directions: wrap UIKit views and controllers, embed SwiftUI in UIKit screens, and synchronize state without duplicating lifecycle ownership.
 
 See [references/representable-recipes.md](references/representable-recipes.md) for complete wrapping recipes and [references/hosting-migration.md](references/hosting-migration.md) for UIKit-to-SwiftUI migration patterns.
 
@@ -388,47 +388,16 @@ If passing closures across isolation boundaries, ensure they are `@Sendable` or 
 
 ## Common Mistakes
 
-### DO / DON'T
-
-**DON'T:** Create the UIKit view in `updateUIView`.
-**DO:** Create the view once in `makeUIView`; only configure/update it in `updateUIView`.
-*Why:* `updateUIView` can run many times. Creating a new view each time destroys all UIKit state (selection, scroll position, first responder) and leaks memory.
-
-**DON'T:** Set delegates in `updateUIView`.
-**DO:** Set delegates in `makeUIView`/`makeUIViewController` only.
-*Why:* Redundant delegate assignment on every update can reset internal delegate state in UIKit views like `WKWebView` or `MKMapView`.
-
-**DON'T:** Mutate the represented view's `frame`, `bounds`, `center`, or `transform`.
-**DO:** Let SwiftUI size the represented view and use `sizeThatFits`, intrinsic size, SwiftUI modifiers, or internal subview layout.
-*Why:* SwiftUI controls those layout properties for the represented view; setting them directly conflicts with SwiftUI layout.
-
-**DON'T:** Hold strong references to the Coordinator from closures.
-**DO:** Use `[weak coordinator]` in closures.
-*Why:* UIKit objects often store closures (completion handlers, action blocks). A strong reference to the coordinator that holds a reference to the UIKit view creates a retain cycle.
-
-**DON'T:** Forget to call `parent.dismiss()` or completion handlers.
-**DO:** Use the coordinator to track dismissal and invoke `parent.dismiss()` in all delegate exit paths.
-*Why:* Modal controllers presented by SwiftUI (via `.sheet`) need their dismiss binding toggled, or the sheet state becomes inconsistent.
-
-**DON'T:** Ignore `dismantleUIView` for views that hold observers or timers.
-**DO:** Clean up `NotificationCenter` observers, `Combine` subscriptions, and `Timer` instances in `dismantleUIView`.
-*Why:* Without cleanup, observers and timers continue firing after the view is removed, causing crashes or stale state updates.
-
-**DON'T:** Force `UIHostingController`'s view to fill the parent without proper constraints.
-**DO:** Use Auto Layout constraints or `sizingOptions` for proper embedding.
-*Why:* Setting `frame` manually breaks adaptive layout, trait propagation, and safe area handling.
-
-**DON'T:** Try to use `@State` in the Coordinator -- it is not a `View`.
-**DO:** Use regular stored properties on the Coordinator and communicate to SwiftUI via `parent`'s `@Binding` properties.
-*Why:* `@State` only works inside `View` conformances. Using it on a class has no effect.
-
-**DON'T:** Poll `withObservationTracking` from a UIKit controller.
-**DO:** Use UIKit automatic observation tracking hooks on iOS 18+/26+, and explicit Combine/callback invalidation for older deployment targets.
-*Why:* Manual `withObservationTracking` is one-shot, and UIKit automatic tracking is not an iOS 17 feature.
-
-**DON'T:** Skip the `addChild`/`didMove(toParent:)` dance when embedding `UIHostingController`.
-**DO:** Always call `addChild(_:)`, add the view to the hierarchy, then call `didMove(toParent:)`.
-*Why:* Skipping containment causes viewWillAppear/viewDidAppear to never fire, breaks trait collection propagation, and causes visual glitches.
+| Mistake | Fix |
+|---|---|
+| UIKit object or delegate recreated in `update*` | Create once in `make*`; update only changed state. |
+| Represented frame/bounds/transform mutated directly | Let SwiftUI size it; use intrinsic size, `sizeThatFits`, modifiers, or internal layout. |
+| Coordinator retained by UIKit closures | Capture it weakly and keep one lifecycle owner. |
+| Picker/controller exit path misses dismissal or completion | Route every delegate exit through one coordinator cleanup path. |
+| Observers, timers, or subscriptions outlive the view | Remove/cancel them in `dismantle*`. |
+| Hosting controller uses manual frame without containment | Use Auto Layout and `addChild`/`didMove(toParent:)`. |
+| `@State` used inside a coordinator | Use stored properties and communicate through bindings/callbacks. |
+| `withObservationTracking` is polled manually | Use UIKit automatic observation hooks where available or explicit invalidation on older targets. |
 
 ## Review Checklist
 

--- a/skills/tabletopkit/SKILL.md
+++ b/skills/tabletopkit/SKILL.md
@@ -7,9 +7,7 @@ description: "Builds multiplayer spatial board games using TabletopKit on vision
 
 Create multiplayer spatial board games on a virtual table surface using
 TabletopKit. Handles game layout, equipment interaction, player seating, turn
-management, state synchronization, and RealityKit rendering. TabletopKit is
-visionOS-only. Core APIs are visionOS 2.0+; availability-sensitive APIs are
-called out below. Targets Swift 6.3.
+management, state synchronization, and RealityKit rendering. It is visionOS-only; the availability matrix below owns version details.
 
 ## Contents
 
@@ -447,8 +445,6 @@ network coordinators and arbiter role management.
 
 ## Common Mistakes
 
-- **Forgetting platform restriction.** TabletopKit is visionOS-only. Do not
-  conditionally compile for iOS/macOS; the framework does not exist there.
 - **Skipping seat claim.** Players must call `claimAnySeat()` or `claimSeat(_:)`
   before interacting with equipment. Without a seat, actions are rejected.
 - **Mutating state outside actions.** All state changes must go through
@@ -473,8 +469,7 @@ network coordinators and arbiter role management.
 
 ## Review Checklist
 
-- [ ] `import TabletopKit` present; answer explicitly states TabletopKit is visionOS-only and target is visionOS 2.0+
-- [ ] Availability checked for visionOS 2.2+ `TabletopInteraction.Configuration` and visionOS 26.0+ custom action/custom state APIs
+- [ ] Platform/availability matrix applied: visionOS-only core 2.0+, interaction configuration 2.2+, and named custom action/state APIs 26.0+
 - [ ] `TableSetup` created with a `Tabletop`/`EntityTabletop` conforming type
 - [ ] All equipment conforms to `Equipment` or `EntityEquipment` with correct state type
 - [ ] Seats added and `claimAnySeat()` / `claimSeat(_:)` called at game start

--- a/skills/vision-framework/SKILL.md
+++ b/skills/vision-framework/SKILL.md
@@ -6,8 +6,7 @@ description: "Implement computer vision features including text recognition (OCR
 # Vision Framework
 
 Detect text, faces, barcodes, objects, and body poses in images and video using
-on-device computer vision. Patterns target iOS 26+ with Swift 6.3,
-backward-compatible where noted.
+on-device computer vision. Prefer the modern iOS 18+ request APIs and load the legacy reference only when the deployment target requires it.
 
 See [references/vision-requests.md](references/vision-requests.md) for complete code patterns and
 [references/visionkit-scanner.md](references/visionkit-scanner.md) for DataScannerViewController integration.
@@ -73,25 +72,7 @@ func recognizeText(in image: CGImage) async throws -> [String] {
 
 ### Legacy Pattern (Pre-iOS 18)
 
-Use `VNImageRequestHandler` with completion-based requests when targeting
-older deployment versions.
-
-```swift
-import Vision
-
-func recognizeTextLegacy(in image: CGImage) throws -> [String] {
-    var recognized: [String] = []
-    let request = VNRecognizeTextRequest { request, error in
-        guard let observations = request.results as? [VNRecognizedTextObservation] else { return }
-        recognized = observations.compactMap { $0.topCandidates(1).first?.string }
-    }
-    request.recognitionLevel = .accurate
-
-    let handler = VNImageRequestHandler(cgImage: image)
-    try handler.perform([request])
-    return recognized
-}
-```
+For pre-iOS 18 targets, use the corresponding `VNRequest` with `VNImageRequestHandler` or `VNSequenceRequestHandler`. Load [references/vision-requests.md](references/vision-requests.md) for complete legacy request and handler patterns.
 
 ## Text Recognition (OCR)
 
@@ -118,16 +99,7 @@ for observation in observations {
 
 ### Legacy: VNRecognizeTextRequest
 
-```swift
-let request = VNRecognizeTextRequest()
-request.recognitionLevel = .accurate
-request.recognitionLanguages = ["en-US", "fr-FR"]
-request.usesLanguageCorrection = true
-```
-
-**Key differences:** Modern API uses `Locale.Language` for languages; legacy
-uses string identifiers. Both support `.accurate` (best quality) and `.fast`
-(real-time suitable) recognition levels.
+The legacy request uses string language identifiers and the handler pattern in the reference; both generations support accurate and fast recognition levels.
 
 ## Face Detection
 
@@ -239,17 +211,7 @@ let maskBuffer = mask.pixelBuffer
 
 ### Legacy: VNGeneratePersonSegmentationRequest
 
-```swift
-let request = VNGeneratePersonSegmentationRequest()
-request.qualityLevel = .accurate  // .balanced, .fast
-request.outputPixelFormat = kCVPixelFormatType_OneComponent8
-
-let handler = VNImageRequestHandler(cgImage: cgImage)
-try handler.perform([request])
-
-guard let mask = request.results?.first?.pixelBuffer else { return }
-// Apply mask using Core Image: CIFilter.blendWithMask()
-```
+For older targets, `VNGeneratePersonSegmentationRequest` exposes its mask through the first pixel-buffer observation; use the reference's handler and mask-composition recipe.
 
 Quality levels:
 - `.accurate` -- best quality, slowest (~1s), full resolution
@@ -316,18 +278,7 @@ Modern `TrackObjectRequest` has no `trackingLevel` or `qualityLevel`.
 
 ### Legacy: VNTrackObjectRequest
 
-```swift
-let trackRequest = VNTrackObjectRequest(detectedObjectObservation: initialObservation)
-trackRequest.trackingLevel = .accurate
-
-let sequenceHandler = VNSequenceRequestHandler()
-// For each frame:
-try sequenceHandler.perform([trackRequest], on: pixelBuffer)
-if let result = trackRequest.results?.first {
-    let updatedBounds = result.boundingBox
-    trackRequest.inputObservation = result
-}
-```
+For older targets, use `VNTrackObjectRequest` with one retained `VNSequenceRequestHandler` and feed each result back as the next input observation. The reference contains the complete loop.
 
 ## Other Request Types
 

--- a/skills/weatherkit/SKILL.md
+++ b/skills/weatherkit/SKILL.md
@@ -6,8 +6,7 @@ description: "Fetch WeatherKit current, minute, hourly, and daily forecasts; wea
 # WeatherKit
 
 Fetch current conditions, hourly and daily forecasts, weather alerts, and
-historical statistics using `WeatherService`. Display required Apple Weather
-attribution. Targets Swift 6.3 / iOS 26+.
+historical statistics using `WeatherService`. Display required Apple Weather attribution.
 
 ## Contents
 
@@ -229,18 +228,6 @@ let minuteForecast = try await weatherService.weather(
 | `.changes` | `WeatherChanges?` | Significant upcoming weather changes (iOS 18+) |
 | `.historicalComparisons` | `HistoricalComparisons?` | Current weather compared to historical averages (iOS 18+) |
 
-### Dashboard Review Checklist
-
-For a current-temperature and alert dashboard review, explicitly cover:
-- Selective `.current, .alerts` queries instead of `weather(for:)` for every dataset
-- No unconditional `onAppear`/`.task` network fetch; use model or cache `loadIfNeeded`
-- `WeatherMetadata.expirationDate` cache freshness
-- `WeatherService.shared.attribution`, mark URLs, and `legalPageURL` beside weather data
-- Optional `alert.region`, non-optional `alert.detailsURL`, and alert detail links
-- `WeatherAvailability` only for `alertAvailability` and `minuteAvailability`
-- `Measurement<UnitTemperature>.formatted()` for displayed temperatures
-- WeatherKit capability/App ID setup and location permission when using device location
-
 ## Context Queries
 
 Use the iOS 18+ context queries when the app needs to explain why today's
@@ -280,42 +267,7 @@ func fetchAttribution() async throws -> WeatherAttribution {
 }
 ```
 
-### Displaying Attribution in SwiftUI
-
-```swift
-import SwiftUI
-import WeatherKit
-
-struct WeatherAttributionView: View {
-    let attribution: WeatherAttribution
-    @Environment(\.colorScheme) private var colorScheme
-
-    var body: some View {
-        VStack {
-            // Display the Apple Weather mark
-            AsyncImage(url: markURL) { image in
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 20)
-            } placeholder: {
-                EmptyView()
-            }
-
-            // Link to the legal attribution page
-            Link("Weather data sources", destination: attribution.legalPageURL)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var markURL: URL {
-        colorScheme == .dark
-            ? attribution.combinedMarkDarkURL
-            : attribution.combinedMarkLightURL
-    }
-}
-```
+Load [references/weatherkit-patterns.md](references/weatherkit-patterns.md) for the complete SwiftUI attribution view and cache integration.
 
 ### Attribution Properties
 
@@ -357,21 +309,7 @@ func checkAvailability(for location: CLLocation) async throws {
 
 ### DON'T: Ship without Apple Weather attribution
 
-Omitting attribution violates the WeatherKit terms of service and risks App Review
-rejection.
-
-```swift
-// WRONG: Show weather data without attribution
-VStack {
-    Text("72F, Sunny")
-}
-
-// CORRECT: Always include attribution
-VStack {
-    Text("72F, Sunny")
-    WeatherAttributionView(attribution: attribution)
-}
-```
+Display the appropriate Apple Weather mark and link `legalPageURL` wherever WeatherKit data appears; use `legalAttributionText` only when the legal page cannot be shown.
 
 ### DON'T: Fetch all datasets when you only need current conditions
 

--- a/skills/widgetkit/SKILL.md
+++ b/skills/widgetkit/SKILL.md
@@ -349,10 +349,7 @@ On watchOS, contextual relevance uses
 - **Use `Canvas` for dense visualizations** like sparklines or mini bar charts.
   The lack of per-element accessibility is acceptable since the entire widget
   surface is a single tap target.
-- **Match timeline refresh to data granularity.** Apple budgets
-  [40–70 refreshes per day](https://sosumi.ai/documentation/widgetkit/keeping-a-widget-up-to-date)
-  with entries at least 5 minutes apart. Use `Text(timerInterval:countsDown:)`
-  for live countdowns instead of burning timeline entries.
+- **Match timeline refresh to data granularity.** The budget is dynamic and opportunistic; schedule useful future entries, avoid unnecessary reloads, and use `Text(timerInterval:countsDown:)` for live countdowns. Load the advanced reference for current budget guidance.
 
 See [references/widgetkit-advanced.md](references/widgetkit-advanced.md) for
 code examples and detailed guidance on each pattern.
@@ -413,24 +410,21 @@ opening the app, CarPlay integration.
    synchronously with sample data. Use `getTimeline` or `timeline(for:in:)` for
    async work.
 
-5. **Letting WidgetKit absorb sibling-skill work.** Keep full Live Activity
-   lifecycle in `activitykit` and full App Intent modeling in `app-intents`.
-
-6. **Treating WidgetKit push payloads as state.** Widget and control pushes are
+5. **Treating WidgetKit push payloads as state.** Widget and control pushes are
    reload signals. Persist state in shared storage or refetch it in the provider.
 
-7. **Registering widget pushes through User Notifications.** Widget push tokens
+6. **Registering widget pushes through User Notifications.** Widget push tokens
    come from WidgetKit handlers, not `UNUserNotificationCenter`.
 
-8. **Putting heavy logic in the widget view.** Widget views are rendered in a
+7. **Putting heavy logic in the widget view.** Widget views are rendered in a
    size-limited process. Pre-compute data in the timeline provider and pass
    display-ready values through the entry.
 
-9. **Ignoring accessory rendering modes.** Lock Screen widgets render in
+8. **Ignoring accessory rendering modes.** Lock Screen widgets render in
    `.vibrant` or `.accented` mode, not `.fullColor`. Test with
    `@Environment(\.widgetRenderingMode)` and avoid relying on color alone.
 
-10. **Not testing on device.** StandBy, CarPlay, and accessory rendering differ
+9. **Not testing on device.** StandBy, CarPlay, and accessory rendering differ
     significantly from Simulator. Always verify on physical hardware.
 
 ## Review Checklist

--- a/tessl.json
+++ b/tessl.json
@@ -4,6 +4,9 @@
   "dependencies": {
     "tessl-labs/tessl-skill-eval-scenarios": {
       "version": "0.1.0"
+    },
+    "tessl/skill-optimizer": {
+      "version": "0.16.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- audit the published 3.8.0 Tessl Quality results for all 86 skills
- revise the 61 skills that scored below 100 across Content, Description, or Validation
- reduce duplicated guidance and move advanced material into directly routed references
- correct several Apple API, concurrency, lifecycle, and framework-boundary issues found during review
- add PhotoKit and SwiftData scenarios so retained root scenario coverage reaches all 86 skills
- install `tessl/skill-optimizer@0.16.0` as a project dependency for future controlled workflows

## Why

The registry feedback was concentrated in conciseness, workflow clarity, progressive disclosure, line count, and a small number of validation/link-parser findings. Some suggestions were false positives or would have removed necessary safety, availability, entitlement, or lifecycle constraints, so the changes apply only the recommendations that held up under source and local validation.

## Validation

- all 86 skills pass `skills-ref validate`
- all 86 skills pass `skill-creator/scripts/quick_validate.py`
- all 258 retained scenarios have the required files, valid weighted criteria, and totals of 100
- `tessl plugin lint .` passes; the only advisory is the previously published-100 `push-notifications` token estimate
- 17 repository tests pass
- `git diff --check` passes
- GitNexus change analysis reports low risk and no affected execution flows
- fresh-context local PhotoKit and SwiftData forward tests passed; their baselines also passed, so those scenarios are treated as activation/regression coverage rather than evidence of skill lift

## Tessl usage and release scope

No Tessl review, scenario-generation, evaluation, optimization, retry, publish, or release command was run. This PR does not change the plugin version and does not create a GitHub release or registry release.