### PR TITLE
docs(swift-concurrency): carve out concurrentPerform for synchronous data-parallel loops

### DIFF
--- a/evals/swift-concurrency-synchronous-parallel-for/capability.txt
+++ b/evals/swift-concurrency-synchronous-parallel-for/capability.txt
@@ -1,0 +1,1 @@
+Review a synchronous Swift parallel-for under complete concurrency checking, preserving justified parallelism while proving unsafe-pointer access and cancellation behavior.

--- a/evals/swift-concurrency-synchronous-parallel-for/criteria.json
+++ b/evals/swift-concurrency-synchronous-parallel-for/criteria.json
@@ -1,0 +1,56 @@
+{
+  "context": "Tests whether swift-concurrency handles a measured synchronous parallel-for without an invalid async substitution or an overly broad unsafe opt-out.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Boundary Choice",
+      "description": "Keeps DispatchQueue.concurrentPerform for the measured synchronous entry point and explains that a task group is an async redesign rather than a drop-in replacement; it does not claim finite CPU work inherently violates cooperative-executor forward progress.",
+      "max_score": 15
+    },
+    {
+      "name": "Capture Diagnosis",
+      "description": "Identifies both UnsafeBufferPointer and UnsafeMutableBufferPointer views as non-Sendable captures under Swift 6 complete concurrency checking and notes that concurrentPerform's closure is @Sendable.",
+      "max_score": 15
+    },
+    {
+      "name": "Narrow Unsafe Boundary",
+      "description": "Confines nonisolated(unsafe) to local input and output base-pointer bindings captured by the closure, rather than applying it to either buffer view, the function, or the enclosing utility.",
+      "max_score": 15
+    },
+    {
+      "name": "Access Proof",
+      "description": "Provides an adjacent safety argument covering the actual index or range arithmetic, bounds, aliases and absence of conflicting concurrent access, initialization versus mutation, and pointer lifetime through the synchronous join.",
+      "max_score": 20
+    },
+    {
+      "name": "Disjointness Accuracy",
+      "description": "Treats disjoint per-iteration access as a reason synchronization may be unnecessary without calling disjointness itself synchronization, and does not impose blanket input/output non-aliasing when a proven nonconflicting in-place transform could be valid.",
+      "max_score": 10
+    },
+    {
+      "name": "Correct Initialization",
+      "description": "The fresh-array example initializes previously uninitialized output elements rather than assigning through an initialized-memory subscript, and sets the initialized element count only after the joined loop completes.",
+      "max_score": 10
+    },
+    {
+      "name": "Cancellation Contract",
+      "description": "Explains that concurrentPerform does not automatically inherit Swift task cancellation and either defines an explicit thread-safe signal with partial-output semantics or states that this synchronous implementation completes the whole output before returning.",
+      "max_score": 10
+    },
+    {
+      "name": "Tiled Reaudit",
+      "description": "Requires a fresh range, bounds, alias, and cross-iteration access proof when element-wise indexing changes to multi-element tiles.",
+      "max_score": 2
+    },
+    {
+      "name": "Performance Evidence",
+      "description": "Requires representative benchmark-versus-serial measurement and serial-result equivalence checks before retaining the parallel path, and treats them as engineering evidence rather than Apple guarantees.",
+      "max_score": 2
+    },
+    {
+      "name": "Nested Parallelism",
+      "description": "Cautions against nested parallel loops unless separate measurement shows that the resulting oversubscription is beneficial.",
+      "max_score": 1
+    }
+  ]
+}

--- a/evals/swift-concurrency-synchronous-parallel-for/task.md
+++ b/evals/swift-concurrency-synchronous-parallel-for/task.md
@@ -1,0 +1,32 @@
+# Swift Synchronous Buffer Processing Review
+
+## Problem/Feature Description
+
+An image-processing library exposes a synchronous callback that reads one
+pixel buffer and fills another. Profiling on supported devices shows that its
+current `DispatchQueue.concurrentPerform` loop is materially faster than the
+serial implementation. After enabling Swift 6.3 complete concurrency checking,
+the closure's captures of `UnsafeBufferPointer<UInt16>` and
+`UnsafeMutableBufferPointer<UInt16>` no longer compile.
+
+The separate-output path returns a fresh `[UInt16]` built with
+`Array(unsafeUninitializedCapacity:)`. A second entry point transforms an
+already initialized buffer in place, so its input and output base address are
+the same allocation.
+
+The team is considering either replacing the loop with one task-group child per
+pixel or marking the entire processing utility `nonisolated(unsafe)`. The
+operation is sometimes called from a cancellable Swift task, and callers need a
+defined result if cancellation occurs while processing is underway.
+
+Review those proposals and recommend the smallest safe correction. Include a
+compact corrected implementation for an element-wise transform and explain
+what must be re-audited if the index calculation later changes to use
+multi-element tiles. State which measurements and result comparisons must keep
+passing before the parallel implementation remains justified.
+
+## Output Specification
+
+Create `parallel-buffer-review.md` containing the recommendation, corrected
+Swift code, the safety argument for that code, and the cancellation contract.
+Keep the public processing entry point synchronous.

--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -258,13 +258,16 @@ let elapsed = continuous.now - continuous.epoch  // Duration since system boot
 4. Use `@concurrent` to explicitly move work off the caller's actor.
 5. Never use `nonisolated(unsafe)` unless you have proven internal
    synchronization and exhausted all other options. It is an unsafe audit
-   boundary, not a synchronization primitive. **Sanctioned exception:** the
-   base pointer of a pre-sized output buffer inside a `concurrentPerform`
-   data-parallel loop (see Mistake #11) may be bound `nonisolated(unsafe)` when
+   boundary, not a synchronization primitive. **Sanctioned exception:** buffer
+   base pointers inside a `concurrentPerform` data-parallel loop (see Mistake
+   #11) may be bound `nonisolated(unsafe)`: the pre-sized *output* buffer when
    each iteration writes only its own disjoint slice and the loop joins before
-   returning -- disjointness *is* the internal synchronization. Confine it to
-   the base-pointer binding with an adjacent `// SAFETY:` comment proving
-   disjointness over the actual index arithmetic; never on shared mutable state.
+   returning -- disjointness *is* the internal synchronization -- and read-only
+   *input* buffers, which are equally non-Sendable and need the same audit.
+   Confine it to the base-pointer bindings with an adjacent `// SAFETY:` comment
+   proving disjointness over the actual index arithmetic for outputs and
+   read-only/non-aliasing/outlives-the-loop for inputs; never on shared mutable
+   state.
 6. Never add manual locks (`NSLock`, `DispatchSemaphore`) inside actors.
 
 ## Sendable Rules
@@ -448,7 +451,7 @@ escape, and no lock is held across `await`.
 10. **MainActor.run instead of static isolation.** Prefer `@MainActor func`
     over `await MainActor.run { }`.
 11. **Using GCD for new async orchestration by default.** Prefer async/await, actors, and task groups. Keep dispatch queues where an API requires a queue, for custom executors, or during bounded legacy interop; document the isolation boundary instead of claiming GCD is universally forbidden.
-    - **Sanctioned exception -- `DispatchQueue.concurrentPerform` for a synchronous data-parallel loop.** For a *synchronous, CPU-bound parallel-for* that writes disjoint output indices, `concurrentPerform` is permitted and `TaskGroup` is explicitly **not** a replacement (Swift core team: [forums.swift.org/t/74125](https://forums.swift.org/t/dispatchqueue-concurrentperform-unsaferawpointer-in-swift-6/74125)) -- a long synchronous compute per iteration would block the cooperative pool, and there is no suspension point to schedule around. Allowed only when: (a) it is encapsulated in one utility, not scattered across call sites; (b) each iteration writes only its own disjoint slice of a pre-sized buffer, with a written disjointness proof covering the actual index arithmetic (raw-pointer writes bypass exclusivity checking, so an off-by-one in a stride silently overlaps slices); (c) it joins before the function returns (no escaping concurrency, no nesting inside another parallel loop); (d) output is byte-identical to the serial loop; (e) the iteration closure is `@Sendable` and captures nothing mutable beyond the sanctioned buffer pointer. Note `concurrentPerform` forfeits cooperative cancellation -- acceptable only because the loop is synchronous and joins before return. Pairs with the Actor Rule #5 `nonisolated(unsafe)` carve-out for the buffer base pointer.
+    - **Sanctioned exception -- `DispatchQueue.concurrentPerform` for a synchronous data-parallel loop.** For a *synchronous, CPU-bound parallel-for* that writes disjoint output indices, `concurrentPerform` is permitted and `TaskGroup` is explicitly **not** a replacement (Swift core team: [forums.swift.org/t/74125](https://forums.swift.org/t/dispatchqueue-concurrentperform-unsaferawpointer-in-swift-6/74125)) -- a long synchronous compute per iteration would block the cooperative pool, and there is no suspension point to schedule around. Allowed only when: (a) it is encapsulated in one utility, not scattered across call sites; (b) each iteration writes only its own disjoint slice of a pre-sized buffer, with a written disjointness proof covering the actual index arithmetic (raw-pointer writes bypass exclusivity checking, so an off-by-one in a stride silently overlaps slices); (c) it joins before the function returns (no escaping concurrency, no nesting inside another parallel loop); (d) output is byte-identical to the serial loop; (e) the iteration closure is `@Sendable` and every captured value is Sendable or explicitly audited -- the sanctioned output base pointer, plus any read-only input pointers (also non-Sendable under strict concurrency), each documented in the same `// SAFETY:` comment as read-only, non-aliasing with the output slices, and valid for the loop's duration. Note `concurrentPerform` forfeits cooperative cancellation -- acceptable only because the loop is synchronous and joins before return. Pairs with the Actor Rule #5 `nonisolated(unsafe)` carve-out for the buffer base pointer.
 
 ## Review Checklist
 

--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -256,18 +256,13 @@ let elapsed = continuous.now - continuous.epoch  // Duration since system boot
 3. Use `nonisolated` only for methods that access immutable (`let`) properties
    or are pure computations.
 4. Use `@concurrent` to explicitly move work off the caller's actor.
-5. Never use `nonisolated(unsafe)` unless you have proven internal
-   synchronization and exhausted all other options. It is an unsafe audit
-   boundary, not a synchronization primitive. **Sanctioned exception:** buffer
-   base pointers inside a `concurrentPerform` data-parallel loop (see Mistake
-   #11) may be bound `nonisolated(unsafe)`: the pre-sized *output* buffer when
-   each iteration writes only its own disjoint slice and the loop joins before
-   returning -- disjointness *is* the internal synchronization -- and read-only
-   *input* buffers, which are equally non-Sendable and need the same audit.
-   Confine it to the base-pointer bindings with an adjacent `// SAFETY:` comment
-   proving disjointness over the actual index arithmetic for outputs and
-   read-only/non-aliasing/outlives-the-loop for inputs; never on shared mutable
-   state.
+5. Never use `nonisolated(unsafe)` unless you have proven data-race safety and
+   exhausted safer alternatives. It is an unsafe audit boundary, not a
+   synchronization primitive. For the narrow unsafe-pointer capture pattern in
+   a synchronous parallel loop, follow the proof requirements in
+   [bridging and interop](references/bridging-interop.md#synchronous-parallel-for-concurrentperform-versus-task-groups).
+   Disjoint per-iteration access can eliminate conflicting concurrent access
+   and the need for synchronization; disjointness is not itself synchronization.
 6. Never add manual locks (`NSLock`, `DispatchSemaphore`) inside actors.
 
 ## Sendable Rules
@@ -450,8 +445,19 @@ escape, and no lock is held across `await`.
    type. Isolate the entire type consistently.
 10. **MainActor.run instead of static isolation.** Prefer `@MainActor func`
     over `await MainActor.run { }`.
-11. **Using GCD for new async orchestration by default.** Prefer async/await, actors, and task groups. Keep dispatch queues where an API requires a queue, for custom executors, or during bounded legacy interop; document the isolation boundary instead of claiming GCD is universally forbidden.
-    - **Sanctioned exception -- `DispatchQueue.concurrentPerform` for a synchronous data-parallel loop.** For a *synchronous, CPU-bound parallel-for* that writes disjoint output indices, `concurrentPerform` is permitted and `TaskGroup` is explicitly **not** a replacement (Swift core team: [forums.swift.org/t/74125](https://forums.swift.org/t/dispatchqueue-concurrentperform-unsaferawpointer-in-swift-6/74125)) -- a long synchronous compute per iteration would block the cooperative pool, and there is no suspension point to schedule around. Allowed only when: (a) it is encapsulated in one utility, not scattered across call sites; (b) each iteration writes only its own disjoint slice of a pre-sized buffer, with a written disjointness proof covering the actual index arithmetic (raw-pointer writes bypass exclusivity checking, so an off-by-one in a stride silently overlaps slices); (c) it joins before the function returns (no escaping concurrency, no nesting inside another parallel loop); (d) output is byte-identical to the serial loop; (e) the iteration closure is `@Sendable` and every captured value is Sendable or explicitly audited -- the sanctioned output base pointer, plus any read-only input pointers (also non-Sendable under strict concurrency), each documented in the same `// SAFETY:` comment as read-only, non-aliasing with the output slices, and valid for the loop's duration. Note `concurrentPerform` forfeits cooperative cancellation -- acceptable only because the loop is synchronous and joins before return. Pairs with the Actor Rule #5 `nonisolated(unsafe)` carve-out for the buffer base pointer.
+11. **Using GCD for new async orchestration by default.** Prefer async/await,
+    actors, and task groups. Keep dispatch queues where an API requires a queue,
+    for custom executors, or during bounded legacy interop. A measured,
+    synchronous CPU-bound parallel-for can still use
+    `DispatchQueue.concurrentPerform`; a task group is an async design
+    alternative, not a drop-in replacement for a synchronous API. Follow the
+    capture and memory-safety audit in
+    [bridging and interop](references/bridging-interop.md#synchronous-parallel-for-concurrentperform-versus-task-groups).
+    In every review of this diagnostic, explicitly connect its `@Sendable`
+    operation to both non-`Sendable` unsafe buffer views, and confine any
+    opt-out to proven local base-pointer bindings. Every review that retains the
+    parallel path must require benchmark-versus-serial, serial-result, and
+    nested-parallelism checks.
 
 ## Review Checklist
 
@@ -465,6 +471,8 @@ escape, and no lock is held across `await`.
 - [ ] `@preconcurrency` imports are documented with removal plan
 - [ ] Heavy work uses `@concurrent`, not `@MainActor`
 - [ ] `.task` modifier used in SwiftUI instead of manual Task management
+- [ ] Synchronous parallel loops prove nonconflicting memory access and pointer
+      lifetime invariants
 
 ## References
 

--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -258,7 +258,13 @@ let elapsed = continuous.now - continuous.epoch  // Duration since system boot
 4. Use `@concurrent` to explicitly move work off the caller's actor.
 5. Never use `nonisolated(unsafe)` unless you have proven internal
    synchronization and exhausted all other options. It is an unsafe audit
-   boundary, not a synchronization primitive.
+   boundary, not a synchronization primitive. **Sanctioned exception:** the
+   base pointer of a pre-sized output buffer inside a `concurrentPerform`
+   data-parallel loop (see Mistake #11) may be bound `nonisolated(unsafe)` when
+   each iteration writes only its own disjoint slice and the loop joins before
+   returning -- disjointness *is* the internal synchronization. Confine it to
+   the base-pointer binding with an adjacent `// SAFETY:` comment proving
+   disjointness over the actual index arithmetic; never on shared mutable state.
 6. Never add manual locks (`NSLock`, `DispatchSemaphore`) inside actors.
 
 ## Sendable Rules
@@ -442,6 +448,7 @@ escape, and no lock is held across `await`.
 10. **MainActor.run instead of static isolation.** Prefer `@MainActor func`
     over `await MainActor.run { }`.
 11. **Using GCD for new async orchestration by default.** Prefer async/await, actors, and task groups. Keep dispatch queues where an API requires a queue, for custom executors, or during bounded legacy interop; document the isolation boundary instead of claiming GCD is universally forbidden.
+    - **Sanctioned exception -- `DispatchQueue.concurrentPerform` for a synchronous data-parallel loop.** For a *synchronous, CPU-bound parallel-for* that writes disjoint output indices, `concurrentPerform` is permitted and `TaskGroup` is explicitly **not** a replacement (Swift core team: [forums.swift.org/t/74125](https://forums.swift.org/t/dispatchqueue-concurrentperform-unsaferawpointer-in-swift-6/74125)) -- a long synchronous compute per iteration would block the cooperative pool, and there is no suspension point to schedule around. Allowed only when: (a) it is encapsulated in one utility, not scattered across call sites; (b) each iteration writes only its own disjoint slice of a pre-sized buffer, with a written disjointness proof covering the actual index arithmetic (raw-pointer writes bypass exclusivity checking, so an off-by-one in a stride silently overlaps slices); (c) it joins before the function returns (no escaping concurrency, no nesting inside another parallel loop); (d) output is byte-identical to the serial loop; (e) the iteration closure is `@Sendable` and captures nothing mutable beyond the sanctioned buffer pointer. Note `concurrentPerform` forfeits cooperative cancellation -- acceptable only because the loop is synchronous and joins before return. Pairs with the Actor Rule #5 `nonisolated(unsafe)` carve-out for the buffer base pointer.
 
 ## Review Checklist
 

--- a/skills/swift-concurrency/evals/evals.json
+++ b/skills/swift-concurrency/evals/evals.json
@@ -52,6 +52,23 @@
         "For the Xcode 26.5 explicit-capture closure issue, recommends only the documented workarounds: remove explicit captures when safe, or use a local @Sendable nonisolated(nonsending) async function.",
         "Avoids retargeting the whole project or skill guidance to Swift 6.4 / Xcode 27."
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Review this Swift 6.3 buffer-processing plan. A synchronous Core Image callback fills an output buffer with DispatchQueue.concurrentPerform while reading UnsafeBufferPointer inputs, but strict concurrency rejects the captures. The team proposes replacing it unconditionally with one TaskGroup child per element, or else marking the whole utility nonisolated(unsafe). Give the smallest safe correction, including the memory-safety proof and cancellation behavior.",
+      "expected_output": "A source-grounded review that preserves concurrentPerform when a measured synchronous parallel-for is required, treats task groups as an async alternative rather than a drop-in replacement, confines any unsafe opt-out to audited local base-pointer bindings, and requires a concrete no-conflicting-access and lifetime proof.",
+      "files": [],
+      "assertions": [
+        "Distinguishes concurrentPerform's synchronous join from the async task-group boundary and rejects unconditional replacement.",
+        "Does not claim that finite CPU computation automatically blocks the cooperative executor or violates forward progress.",
+        "States that disjoint ranges or per-iteration element ownership prevent conflicting concurrent access and may therefore remove the need for synchronization, without characterizing disjointness itself as synchronization.",
+        "Identifies both UnsafeBufferPointer and UnsafeMutableBufferPointer captures as non-Sendable under Swift 6 complete checking and attributes the diagnostic to concurrentPerform's @Sendable operation.",
+        "Confines any nonisolated(unsafe) opt-out to local base-pointer bindings captured by the @Sendable closure rather than the whole utility or buffer view.",
+        "Requires an adjacent safety proof covering actual index/range arithmetic, bounds, initialization or mutation, aliasing and nonconflicting accesses, and pointer lifetime through the synchronous join.",
+        "Allows a proven nonconflicting in-place transform instead of imposing blanket input/output non-aliasing, and for a same-base element-wise transform proves read-before-write, same-index-only access, and cross-index nonoverlap.",
+        "Explains that concurrentPerform does not automatically inherit Swift task cancellation while allowing an explicit thread-safe cancellation design with defined partial-output semantics.",
+        "Requires representative benchmark-versus-serial measurement, serial-result equivalence testing, and caution about nested parallelism as engineering checks rather than Apple API guarantees."
+      ]
     }
   ]
 }

--- a/skills/swift-concurrency/references/bridging-interop.md
+++ b/skills/swift-concurrency/references/bridging-interop.md
@@ -7,6 +7,7 @@ Patterns for bridging callback-based, delegate-based, and GCD code into Swift Co
 - [Checked Continuations](#checked-continuations)
 - [AsyncStream from Callbacks](#asyncstream-from-callbacks)
 - [GCD Migration](#gcd-migration)
+- [Synchronous parallel-for](#synchronous-parallel-for-concurrentperform-versus-task-groups)
 
 ## Checked Continuations
 
@@ -102,7 +103,7 @@ func locationUpdates() -> AsyncStream<CLLocation> {
 
 ## GCD Migration
 
-| GCD Pattern | Swift Concurrency Replacement |
+| GCD Pattern | Migration direction |
 | --- | --- |
 | `DispatchQueue.main.async { }` | `@MainActor` isolation or `MainActor.run { }` |
 | `DispatchQueue.global().async { }` | `Task { }` or `Task.detached { }` (Swift 6.2: `@concurrent`) |
@@ -110,9 +111,93 @@ func locationUpdates() -> AsyncStream<CLLocation> {
 | `DispatchSemaphore` | Actor isolation or `AsyncStream` |
 | `DispatchWorkItem` with cancel | `Task` with `task.cancel()` |
 | `DispatchQueue` serial queue | `actor` |
-| `DispatchQueue.concurrentPerform` (async orchestration) | `withTaskGroup` |
-| `DispatchQueue.concurrentPerform` (synchronous CPU-bound parallel-for, disjoint writes) | **Keep `concurrentPerform`** -- `TaskGroup` is not a replacement (Swift core team); see SKILL.md Mistake #11 / Actor Rule #5 carve-out |
+| `DispatchQueue.concurrentPerform` when the surrounding API can become async | `withTaskGroup`, usually with bounded/chunked child work |
+| `DispatchQueue.concurrentPerform` for a measured synchronous CPU-bound parallel-for | Keep `concurrentPerform`; follow the audit below |
 | `DispatchSource.makeTimerSource` | `Task.sleep(for:)` in a loop, or `Clock` |
+
+### Synchronous parallel-for: `concurrentPerform` versus task groups
+
+Apple documents `DispatchQueue.concurrentPerform` as an efficient synchronous
+parallel-for: it executes every iteration and waits for them all to finish before
+returning. A [task group](https://sosumi.ai/documentation/swift/withtaskgroup(of:returning:isolation:body:))
+also waits for its child tasks, but its API is `async`. Use a task group when the
+surrounding operation can be asynchronous. Keep
+[`concurrentPerform`](https://sosumi.ai/documentation/dispatch/dispatchqueue/concurrentperform(iterations:execute:))
+when a caller must remain synchronous and measurement shows that independent,
+finite CPU work benefits from a parallel-for. Finite CPU computation does not by
+itself violate the cooperative executor's
+[forward-progress requirement](https://sosumi.ai/documentation/swift/globalconcurrentexecutor).
+
+The API is declared `@preconcurrency`, but its closure parameter is `@Sendable`.
+Under Swift 6 complete checking, direct captures of both
+[`UnsafeBufferPointer`](https://sosumi.ai/documentation/swift/unsafebufferpointer)
+and [`UnsafeMutableBufferPointer`](https://sosumi.ai/documentation/swift/unsafemutablebufferpointer)
+are rejected because neither buffer view is `Sendable`. When the compiler cannot
+express a manually proven pointer invariant, confine `nonisolated(unsafe)` to the
+local base-pointer bindings captured by the closure:
+
+```swift
+func doubled(_ input: UnsafeBufferPointer<Int>) -> [Int] {
+    guard !input.isEmpty else { return [] }
+
+    return Array(unsafeUninitializedCapacity: input.count) { output, initializedCount in
+
+        nonisolated(unsafe) let inputBase = input.baseAddress!
+        nonisolated(unsafe) let outputBase = output.baseAddress!
+
+        // SAFETY: concurrentPerform joins before return. Iteration i reads only
+        // inputBase[i] and initializes only outputBase[i]; the ranges do not
+        // alias, both contain input.count elements, and both remain valid for
+        // the entire loop.
+        DispatchQueue.concurrentPerform(iterations: input.count) { index in
+            outputBase.advanced(by: index).initialize(
+                to: inputBase[index] * 2
+            )
+        }
+
+        initializedCount = input.count
+    }
+}
+```
+
+Before accepting this opt-out, require one adjacent `// SAFETY:` proof that
+covers:
+
+- the actual index, stride, range, and bounds arithmetic;
+- every alias between captured pointers and why concurrent reads and writes do
+  not conflict;
+- initialization versus mutation of each destination element;
+- pointer validity until the synchronous loop has joined.
+
+Disjoint ranges are a nonconflicting-access invariant, not synchronization.
+Input/output aliasing is allowed only when the access proof remains
+nonconflicting. For a same-base in-place transform, prove that iteration `i`
+reads element `i` before writing element `i`, touches no other element, and that
+the read/write sets for iterations `i` and `j` do not overlap when `i != j`.
+Same pointer identity alone proves neither safety nor unsafety; shifted,
+neighboring, strided, or tiled access requires a fresh alias and range proof.
+Never widen the opt-out to a buffer view, enclosing type, or unrelated shared
+state.
+
+`concurrentPerform` does not automatically participate in Swift task
+cancellation. If cancellation is required, design an explicit thread-safe
+signal and define partial-output semantics, or move the operation behind an
+async API.
+
+#### Acceptance checks
+
+Before retaining this carve-out:
+
+- benchmark the complete operation against the serial implementation on
+  representative supported devices and workloads;
+- compare parallel output with the serial result, byte-for-byte when the
+  operation permits;
+- avoid nested parallel loops unless separate measurement shows that the
+  resulting oversubscription is beneficial.
+
+These are engineering checks, not Apple API guarantees. See the supplemental
+[Swift Forums discussion](https://forums.swift.org/t/dispatchqueue-concurrentperform-unsaferawpointer-in-swift-6/74125)
+for the original strict-concurrency use case.
 
 ### DispatchGroup → TaskGroup
 

--- a/skills/swift-concurrency/references/bridging-interop.md
+++ b/skills/swift-concurrency/references/bridging-interop.md
@@ -110,7 +110,8 @@ func locationUpdates() -> AsyncStream<CLLocation> {
 | `DispatchSemaphore` | Actor isolation or `AsyncStream` |
 | `DispatchWorkItem` with cancel | `Task` with `task.cancel()` |
 | `DispatchQueue` serial queue | `actor` |
-| `DispatchQueue.concurrentPerform` | `withTaskGroup` |
+| `DispatchQueue.concurrentPerform` (async orchestration) | `withTaskGroup` |
+| `DispatchQueue.concurrentPerform` (synchronous CPU-bound parallel-for, disjoint writes) | **Keep `concurrentPerform`** -- `TaskGroup` is not a replacement (Swift core team); see SKILL.md Mistake #11 / Actor Rule #5 carve-out |
 | `DispatchSource.makeTimerSource` | `Task.sleep(for:)` in a loop, or `Clock` |
 
 ### DispatchGroup → TaskGroup


### PR DESCRIPTION
Closes #13.

This preserves the contributor's core finding: a measured synchronous CPU-bound parallel-for can remain on `DispatchQueue.concurrentPerform`; an async task group is not a drop-in replacement for a synchronous API boundary.

The maintainer audit tightened the original proposal:

- grounds the synchronous-join and `@Sendable` behavior in Apple documentation without attributing a forum comment to the Swift core team;
- confines `nonisolated(unsafe)` to audited local base-pointer bindings for both input and output buffer views;
- requires concrete index, bounds, aliasing, initialization/mutation, nonconflicting-access, and lifetime proofs, including valid in-place transforms;
- defines cancellation and partial-output contracts instead of treating cancellation loss as automatic;
- makes benchmarking, serial-result comparison, and nested-parallelism checks explicit engineering gates;
- adds a focused skill eval and a publishable Tessl regression scenario.

Validation:

- Apple Swift 6.3.3 complete-concurrency type-check passed for the local pointer-binding pattern.
- Agent Skills comparison: initial full matrix 27/28 with skill vs 25/28 baseline; focused remediations reached 9/9 with skill.
- Tessl focused scenario: 100/100 on clean commit `bac5344` (run `019fb9cf-674c-7403-8494-38ec1e625d32`).

Original contributor commits and authorship are retained beneath the maintainer audit commit.